### PR TITLE
[WHISPR-115] Add a Terraform CI workflow

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -1,0 +1,35 @@
+name: Terraform CI
+
+on:
+  push:
+    paths:
+      - '**.tf'
+      - '.github/workflows/terraform-ci.yml'
+  pull_request:
+    paths:
+      - '**.tf'
+      - '.github/workflows/terraform-ci.yml'
+
+jobs:
+  terraform:
+    name: Terraform Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Run tfsec (Security Scanner)
+        uses: aquasecurity/tfsec-action@v1.0.0

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
-      - name: Run tfsec (Security Scanner)
-        uses: aquasecurity/tfsec-action@v1.0.0
-        with:
-          working_directory: ${{ matrix.tf-dir }}
+    #   - name: Run tfsec (Security Scanner)
+    #     uses: aquasecurity/tfsec-action@v1.0.0
+    #     with:
+    #       working_directory: ${{ matrix.tf-dir }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -1,10 +1,6 @@
 name: Terraform CI
 
 on:
-  push:
-    paths:
-      - '**.tf'
-      - '.github/workflows/terraform-ci.yml'
   pull_request:
     paths:
       - '**.tf'

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -11,9 +11,25 @@ on:
       - '.github/workflows/terraform-ci.yml'
 
 jobs:
+
   terraform:
     name: Terraform Checks
     runs-on: ubuntu-latest
+
+    env:
+      TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+
+    strategy:
+      matrix:
+        tf-dir:
+          - google_kubernetes_engine
+          - kubernetes_cluster
+          - terraform/modules/google_kubernetes_engine
+          - terraform/modules/kubernetes_cluster
+
+    defaults:
+      run:
+        working-directory: ${{ matrix.tf-dir }}
 
     steps:
       - name: Checkout repository
@@ -33,3 +49,5 @@ jobs:
 
       - name: Run tfsec (Security Scanner)
         uses: aquasecurity/tfsec-action@v1.0.0
+        with:
+          working_directory: ${{ matrix.tf-dir }}

--- a/kubernetes_cluster/main.tf
+++ b/kubernetes_cluster/main.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "whispr_gke" {
   organization = "glopez-personnal"
-  workspace   = "whispr-google-kubernetes-engine"
+  workspace    = "whispr-google-kubernetes-engine"
 }
 
 module "kubernetes_cluster" {

--- a/kubernetes_cluster/main.tf
+++ b/kubernetes_cluster/main.tf
@@ -8,6 +8,5 @@ module "kubernetes_cluster" {
 
   gke_cluster_name      = data.tfe_outputs.whispr_gke.values.cluster_name
   argocd_domain         = "argocd.whispr.epitech-msc2026.me"
-  argocd_namespace      = "argocd"
   argocd_admin_password = "" # If empty, a random one will be generated
 }

--- a/kubernetes_cluster/outputs.tf
+++ b/kubernetes_cluster/outputs.tf
@@ -1,7 +1,3 @@
-output "argocd_namespace" {
-  value = module.kubernetes_cluster.argocd_namespace
-}
-
 output "argocd_admin_password" {
   description = "Mot de passe admin ArgoCD"
   value       = nonsensitive(module.kubernetes_cluster.argocd_admin_password)

--- a/terraform/modules/kubernetes_cluster/main.tf
+++ b/terraform/modules/kubernetes_cluster/main.tf
@@ -17,9 +17,9 @@ locals {
 
 resource "kubernetes_namespace" "argocd" {
   metadata {
-    name = var.argocd_namespace
+    name = "argocd"
     labels = {
-      name = var.argocd_namespace
+      name = "argocd"
     }
   }
 }

--- a/terraform/modules/kubernetes_cluster/main.tf
+++ b/terraform/modules/kubernetes_cluster/main.tf
@@ -58,7 +58,7 @@ resource "helm_release" "argocd" {
 resource "kubernetes_manifest" "root_app" {
   manifest = yamldecode(file("${path.module}/app.yaml"))
 
-  depends_on = [ helm_release.argocd ]
+  depends_on = [helm_release.argocd]
 }
 
 

--- a/terraform/modules/kubernetes_cluster/outputs.tf
+++ b/terraform/modules/kubernetes_cluster/outputs.tf
@@ -2,16 +2,11 @@
 # OUTPUTS
 ####################################################################################################
 
-output "argocd_namespace" {
-  value = var.argocd_namespace
-}
-
-
 data "kubernetes_secret" "argocd_initial_admin_secret" {
   depends_on = [helm_release.argocd]
   metadata {
     name      = "argocd-initial-admin-secret"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions CI workflow for Terraform and simplifies the management of the ArgoCD namespace by hardcoding its value to "argocd" throughout the configuration. This removes the need for passing or outputting the namespace as a variable, reducing complexity and potential sources of misconfiguration.

**CI/CD Improvements:**

* Added a new `.github/workflows/terraform-ci.yml` workflow to automatically run Terraform formatting, initialization, and validation on relevant directories when `.tf` files or the workflow file itself are changed. This ensures Terraform code quality and consistency on pull requests.

**Terraform Module Simplification:**

* Hardcoded the ArgoCD namespace to `"argocd"` in `terraform/modules/kubernetes_cluster/main.tf`, removing the `argocd_namespace` variable and related references.
* Updated the `kubernetes_cluster/main.tf` module usage to no longer pass `argocd_namespace`, since it is now fixed.
* Removed the `argocd_namespace` output from both `kubernetes_cluster/outputs.tf` and `terraform/modules/kubernetes_cluster/outputs.tf`, as it is no longer needed. [[1]](diffhunk://#diff-a3826777c569403e698450ee476f410c1a3f1e46642d9ac23295999badbddd1eL1-L4) [[2]](diffhunk://#diff-a72a6148ca0af39a0e7be417d68f78230b763186de2fe6e5956df5ffb43de3b2L5-R9)
* Updated the `namespace` value in the `argocd_initial_admin_secret` data resource to use the hardcoded `"argocd"` value.