### PR TITLE
[WHISPR-115] Update token retrieval to keep it fresh ❄️ 

### DIFF
--- a/google_kubernetes_engine/outputs.tf
+++ b/google_kubernetes_engine/outputs.tf
@@ -6,17 +6,10 @@ output "cluster_name" {
 output "cluster_endpoint" {
   description = "The endpoint to access the GKE cluster"
   value       = module.google_kubernetes_engine.cluster_endpoint
-  sensitive   = true
 }
 
 output "cluster_ca_certificate" {
   description = "The CA certificate for the GKE cluster"
   value       = module.google_kubernetes_engine.cluster_ca_certificate
-  sensitive   = true
-}
-
-output "access_token" {
-  description = "The access token for the GKE cluster"
-  value       = data.google_client_config.default.access_token
   sensitive   = true
 }

--- a/kubernetes_cluster/main.tf
+++ b/kubernetes_cluster/main.tf
@@ -1,7 +1,11 @@
+# Retrieve outputs from the GKE workspace
 data "tfe_outputs" "whispr_gke" {
   organization = "glopez-personnal"
   workspace    = "whispr-google-kubernetes-engine"
 }
+
+# Retrieve a fresh authentication token as the one stored in the other workspace state file may be expired
+data "google_client_config" "default" {}
 
 module "kubernetes_cluster" {
   source = "git::https://github.com/whispr-messenger/infrastructure.git//terraform/modules/kubernetes_cluster?ref=main"

--- a/kubernetes_cluster/providers.tf
+++ b/kubernetes_cluster/providers.tf
@@ -3,7 +3,7 @@
 ####################################################################################################
 provider "kubernetes" {
   host                   = "https://${data.tfe_outputs.whispr_gke.values.cluster_endpoint}"
-  token                  = data.tfe_outputs.whispr_gke.values.access_token
+  token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(data.tfe_outputs.whispr_gke.values.cluster_ca_certificate)
 }
 
@@ -13,7 +13,7 @@ provider "kubernetes" {
 provider "helm" {
   kubernetes {
     host                   = "https://${data.tfe_outputs.whispr_gke.values.cluster_endpoint}"
-    token                  = data.tfe_outputs.whispr_gke.values.access_token
+    token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(data.tfe_outputs.whispr_gke.values.cluster_ca_certificate)
   }
 }


### PR DESCRIPTION
This pull request updates the way the Kubernetes and Helm providers authenticate with the GKE cluster by switching from using a potentially stale access token stored in Terraform Cloud outputs to retrieving a fresh token directly from Google Cloud. It also removes the now-unnecessary output of the access token from the GKE module.

Authentication improvements:

* The `kubernetes` and `helm` providers in `kubernetes_cluster/providers.tf` now use a fresh access token from `data.google_client_config.default.access_token` instead of the possibly expired token from Terraform Cloud outputs. [[1]](diffhunk://#diff-bd2c37ab005244ae2451b0c0906a8e2b234e7769de31aa0af1b1efdb3651e4f1L6-R6) [[2]](diffhunk://#diff-bd2c37ab005244ae2451b0c0906a8e2b234e7769de31aa0af1b1efdb3651e4f1L16-R16)
* Added a new data source in `kubernetes_cluster/main.tf` to retrieve the Google Cloud authentication token directly using `data "google_client_config" "default" {}`.

Terraform output cleanup:

* Removed the `access_token` output from `google_kubernetes_engine/outputs.tf`, as it is no longer needed for downstream modules provider