### PR TITLE
[WHISPR-115] Correct ArgoCD secret name and update admin password output

### DIFF
--- a/terraform/modules/kubernetes_cluster/outputs.tf
+++ b/terraform/modules/kubernetes_cluster/outputs.tf
@@ -5,14 +5,14 @@
 data "kubernetes_secret" "argocd_initial_admin_secret" {
   depends_on = [helm_release.argocd]
   metadata {
-    name      = "argocd-initial-admin-secret"
+    name      = "argocd-secret"
     namespace = "argocd"
   }
 }
 
 output "argocd_admin_password" {
   description = "Mot de passe admin ArgoCD"
-  value       = nonsensitive(data.kubernetes_secret.argocd_initial_admin_secret.data["password"])
+  value       = nonsensitive(data.kubernetes_secret.argocd_initial_admin_secret.data["admin.password"])
   sensitive   = false
 }
 


### PR DESCRIPTION
This pull request updates the way the ArgoCD admin password is retrieved from Kubernetes secrets in the Terraform module. The secret name and the key used to extract the password have both been changed to match new naming conventions.

Secret retrieval updates:

* Changed the `name` field in the `data "kubernetes_secret" "argocd_initial_admin_secret"` resource from `"argocd-initial-admin-secret"` to `"argocd-secret"`, updating which Kubernetes secret is queried.
* Updated the output to retrieve the admin password from the `admin.password` key instead of `password` in the ArgoCD secret.