### PR TITLE
[WHISPR-115] Fix ArgoCD app-of-apps pattern errors

### DIFF
--- a/argocd/applications/infrastructure-applicationset.yaml
+++ b/argocd/applications/infrastructure-applicationset.yaml
@@ -37,7 +37,7 @@ spec:
       source:
         repoURL: https://github.com/whispr-messenger/infrastructure
         targetRevision: HEAD
-        path: '{{path}}'
+        path: '{{.path}}'
       destination:
         server: https://kubernetes.default.svc
         namespace: |

--- a/terraform/modules/kubernetes_cluster/app.yaml
+++ b/terraform/modules/kubernetes_cluster/app.yaml
@@ -6,7 +6,7 @@ metadata:
   # Ensure that all Kubernetes resources deployed by the application are properly
   # deleted before the Application itself is deleted.
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    - resources-finalizer.argocd.argoproj.io/finalizer
 spec:
   project: default
   source:


### PR DESCRIPTION
This pull request makes minor adjustments to configuration files for ArgoCD and Kubernetes to ensure proper templating and resource cleanup behavior.

- ArgoCD ApplicationSet template fix:
  * Updated the `path` field in `argocd/applications/infrastructure-applicationset.yaml` to use the correct Go template variable syntax (`{{.path}}` instead of `{{path}}`).

- Kubernetes resource finalizer update:
  * Changed the finalizer value in `terraform/modules/kubernetes_cluster/app.yaml` to `resources-finalizer.argocd.argoproj.io/finalizer` for accurate resource cleanup on deletion.