### PR TITLE
[WHISPR-115] Fix ArgoCD Configmaps

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -1,4 +1,5 @@
 ---
+# General Argo CD configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,6 +9,7 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
+  # Argo CD's externally facing base URL (optional). Required when configuring SSO
   url: https://argocd.whispr.epitech-msc2026.me
-  server.enable.proxy.extension: "true"
-  server.insecure: "true"  # Since ArgoCD runs HTTP internally behind HTTPS proxy
+  # Enables application status badge feature
+  statusbadge.enabled: "true"

--- a/argocd/infrastructure/argocd-config/argocd-cmd-params-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cmd-params-cm.yaml
@@ -1,0 +1,9 @@
+---
+# Argo CD env variables configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  namespace: argocd
+data:
+  server.insecure: "true"


### PR DESCRIPTION
This pull request updates the Argo CD configuration to improve clarity, enable new features, and better organize configuration files. The most notable changes are the renaming of a key configuration file, enabling the application status badge, and moving certain settings into a dedicated environment variables config map.

**Configuration file organization and clarity:**

* Renamed `configmap.yaml` to `argocd-cm.yaml` in the `argocd/infrastructure/argocd-config` directory and added a comment to clarify its purpose as the general Argo CD configuration.
* Added comments to document configuration options, such as the external base URL and the purpose of certain flags.

**Feature enablement and settings management:**

* Enabled the application status badge feature by adding `statusbadge.enabled: "true"` to the Argo CD config map.
* Moved the `server.insecure: "true"` setting from the main config map to a new dedicated `argocd-cmd-params-cm.yaml` config map for environment variables, improving separation of concerns. [[1]](diffhunk://#diff-bbbf597f36877edf53ad7641961b31d8fbbd4dc086957d2eb8ec8c311c30c132R12-R15) [[2]](diffhunk://#diff-71b6e5fbb4da2519b47146e1df17f28036dd43bdf0965a49ada1c6cfe833eca6R1-R9)
* Removed the `server.enable.proxy.extension` setting from the config map, cleaning up unused or unnecessary configuration.