### PR TITLE
[WHISPR-115] Fix cert-manager Helm chart deployment

### DIFF
--- a/argocd/infrastructure/cert-manager/application.yaml
+++ b/argocd/infrastructure/cert-manager/application.yaml
@@ -8,35 +8,18 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   project: default
-  source:
-    repoURL: https://charts.jetstack.io
+  sources:
+  - repoURL: https://charts.jetstack.io
     chart: cert-manager
-    targetRevision: v1.13.2
+    targetRevision: v1.18.2
     helm:
-      releaseName: cert-manager
-      values: |
-        installCRDs: true
-        namespace: cert-manager
-        startupapicheck:
-          enabled: false
-        serviceAccount:
-          create: true
-        resources:
-          requests:
-            cpu: 10m
-            memory: 32Mi
-          limits:
-            cpu: 100m
-            memory: 128Mi
-        global:
-          leaderElection:
-            namespace: cert-manager
-        webhook:
-          serviceAccount:
-            create: true
-        cainjector:
-          serviceAccount:
-            create: true
+      valueFiles:
+        - $values/argocd/infrastructure/cert-manager/values.yaml
+
+  - repoURL: 'https://github.com/whispr-messenger/infrastructure.git'
+    targetRevision: main
+    ref: values
+
   destination:
     server: https://kubernetes.default.svc
     namespace: cert-manager

--- a/argocd/infrastructure/cert-manager/values.yaml
+++ b/argocd/infrastructure/cert-manager/values.yaml
@@ -1,0 +1,27 @@
+installCRDs: true
+
+startupapicheck:
+  enabled: false
+
+serviceAccount:
+  create: true
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+global:
+  leaderElection:
+    namespace: cert-manager
+
+webhook:
+  serviceAccount:
+    create: true
+
+cainjector:
+  serviceAccount:
+    create: true


### PR DESCRIPTION
This pull request updates the ArgoCD configuration for deploying `cert-manager` by upgrading the Helm chart version, restructuring the source configuration to support value file overrides, and moving Helm values to a separate file for better maintainability.

**Helm chart upgrade and configuration management improvements:**

* Upgraded the `cert-manager` Helm chart from version `v1.13.2` to `v1.18.2` to include the latest features and fixes.
* Refactored the ArgoCD Application manifest to use the `sources` array, enabling the use of value file references and supporting better separation of chart source and configuration.
* Moved all Helm values from inline YAML in `application.yaml` to a dedicated `values.yaml` file, improving readability and maintainability. [[1]](diffhunk://#diff-fb856ee14755c98c4f88afed466f661652a4b190d8be5413defda7950b9a239eL11-R22) [[2]](diffhunk://#diff-4816ac03f8b39614baf7d8cf30343996c9542eedf7b30e1e107a12145e41a251R1-R27)
* Added an additional source to reference the repository containing the new `values.yaml` file, enabling ArgoCD to apply custom values during deployment.