### PR TITLE
[WHISPR-115] Update apiVersion to v1alpha3 for Istio objects

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-gateway.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-gateway.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: argocd-gateway

--- a/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: argocd-virtualservice


### PR DESCRIPTION
This pull request updates the API versions used in the ArgoCD Istio configuration files to ensure compatibility with Istio resources. The changes focus on correcting the `apiVersion` for both the `Gateway` and `VirtualService` manifests.

Istio configuration updates:

* Changed the `apiVersion` in `argocd-gateway.yaml` from `networking.istio.io/v1` to `networking.istio.io/v1alpha3` to match the supported version for Gateway resources.
* Changed the `apiVersion` in `argocd-virtualservice.yaml` from `networking.istio.io/v1` to `networking.istio.io/v1alpha3` to match the supported version for VirtualService resources.