### PR TITLE
[WHISPR-115] Add image repository and tag for istio-ingressgateway

### DIFF
--- a/argocd/applications/istio-gateway.yaml
+++ b/argocd/applications/istio-gateway.yaml
@@ -15,6 +15,9 @@ spec:
     helm:
       releaseName: istio-ingressgateway
       values: |
+        image:
+          repository: docker.io/istio/proxyv2
+          tag: 1.19.0
         service:
           type: LoadBalancer
           annotations:


### PR DESCRIPTION
This pull request makes a small but important change to the Istio Ingress Gateway Helm values, explicitly setting the image repository and tag for the gateway proxy. This ensures that the deployment uses the specified `istio/proxyv2` image at version `1.19.0`.

- Set the `image.repository` to `docker.io/istio/proxyv2` and `image.tag` to `1.19.0` in the Helm values for the Istio Ingress Gateway (`argocd/applications/istio-gateway.yaml`).