### PR TITLE
[WHISPR-115] Mark cluster_endpoint as sensitive in outputs.tf

### DIFF
--- a/google_kubernetes_engine/outputs.tf
+++ b/google_kubernetes_engine/outputs.tf
@@ -6,6 +6,7 @@ output "cluster_name" {
 output "cluster_endpoint" {
   description = "The endpoint to access the GKE cluster"
   value       = module.google_kubernetes_engine.cluster_endpoint
+  sensitive   = true
 }
 
 output "cluster_ca_certificate" {


### PR DESCRIPTION
This pull request introduces a small but important change to the `output "cluster_endpoint"` in the `google_kubernetes_engine/outputs.tf` file. The change marks the cluster endpoint output as sensitive, which helps prevent accidental exposure of sensitive information in logs or outputs.