### PR TITLE
[WHISPR-115] Allow ACME checks in HTTP

### DIFF
--- a/argocd/applications/istio.yaml
+++ b/argocd/applications/istio.yaml
@@ -20,6 +20,7 @@ spec:
           global:
             meshID: mesh1
             network: network1
+
     # 2. Then install control plane
     - repoURL: https://istio-release.storage.googleapis.com/charts
       chart: istiod

--- a/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
@@ -10,16 +10,18 @@ spec:
   gateways:
   - argocd-gateway
   http:
+  # Autorise le challenge ACME HTTP-01 sans redirection
   - match:
     - uri:
-        prefix: /
+        prefix: "/.well-known/acme-challenge/"
     route:
     - destination:
-        host: argocd-server.argocd.svc.cluster.local  # Full FQDN for cross-namespace
+        host: argocd-server.argocd.svc.cluster.local
         port:
           number: 80
-    headers:
-      request:
-        add:
-          x-forwarded-proto: https
-          x-forwarded-ssl: "on"
+  # Redirige tout le reste du trafic HTTP vers HTTPS
+  - match:
+    - uri:
+        prefix: "/"
+    redirect:
+      scheme: https


### PR DESCRIPTION
This pull request updates Istio and ArgoCD VirtualService configurations to improve HTTP routing, particularly for ACME HTTP-01 challenges and secure traffic redirection. The main changes focus on enabling ACME challenges to pass through without redirection and ensuring all other HTTP traffic is redirected to HTTPS.

**Istio and ArgoCD VirtualService configuration updates:**

* Added a specific HTTP route in `argocd-virtualservice.yaml` to allow ACME HTTP-01 challenge requests (`/.well-known/acme-challenge/`) to reach the ArgoCD server without being redirected, which is necessary for certificate issuance.
* Configured a catch-all HTTP route to redirect all other HTTP traffic to HTTPS, enhancing security by ensuring encrypted connections.

**Other configuration update:**

* Minor formatting adjustment in `istio.yaml` with the addition of a blank line for readability.