### PR TITLE
[WHISPR-117] Add automatic labelling to repo content

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,69 @@
+# Labeler configuration for PRs and issues
+# See: https://github.com/actions/labeler
+
+terraform:
+  - '**/*.tf'
+  - 'terraform/**'
+  - 'terraform/**/*.tf'
+
+kubernetes:
+  - '**/kubernetes_cluster/**'
+  - '**/argocd/**'
+  - '**/istio*.yaml'
+  - '**/cert-manager*.yaml'
+  - '**/microservices/**'
+  - '**/*.yaml'
+  - '!**/docker/**'
+
+gcp:
+  - '**/google_kubernetes_engine/**'
+  - '**/setup-gcp-project.sh'
+  - '**/gcp*'
+
+argocd:
+  - '**/argocd/**'
+  - '**/argocd*.yaml'
+
+istio:
+  - '**/istio*.yaml'
+
+cert-manager:
+  - '**/cert-manager*.yaml'
+
+microservices:
+  - '**/microservices/**'
+
+docker:
+  - '**/docker/**'
+  - '**/compose*.yml'
+
+script:
+  - '**/scripts/**'
+  - '**/*.sh'
+
+yaml:
+  - '**/*.yaml'
+  - '**/*.yml'
+
+module:
+  - '**/modules/**'
+
+provider:
+  - '**/providers.tf'
+
+output:
+  - '**/outputs.tf'
+
+application:
+  - '**/applications/**'
+
+setup:
+  - '**/setup*'
+
+project:
+  - '**/project*'
+
+security:
+  - '**/certificate*'
+  - '**/issuer*'
+  - '**/cert-manager*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,75 +1,153 @@
-# Labeler configuration for PRs and issues
-# See: https://github.com/actions/labeler
+# GitHub Labeler Configuration
+# Automatically applies labels based on changed files
 
+# Terraform related files
 terraform:
-  - '**/*.tf'
-  - 'terraform/**'
-  - 'terraform/**/*.tf'
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.tf'
+      - '**/*.tfvars'
+      - '**/*.tfstate'
 
-kubernetes:
-  - '**/kubernetes_cluster/**'
-  - '**/argocd/**'
-  - '**/istio*.yaml'
-  - '**/cert-manager*.yaml'
-  - '**/microservices/**'
-  - '!**/docker/**'
-  # Removed overly broad '**/*.yaml' pattern to avoid false positives
-gcp:
-  - '**/google_kubernetes_engine/**'
-  - '**/setup-gcp-project.sh'
-  - '**/gcp*'
-
-argocd:
-  - '**/argocd/**'
-  - '**/argocd*.yaml'
-
-istio:
-  - '**/istio*.yaml'
-  - '**/istio*.yml'
-
-cert-manager:
-  - '**/cert-manager*.yaml'
-  - '**/cert-manager*.yml'
-
-microservices:
-  - '**/microservices/**'
-
-docker:
-  - '**/docker/**'
-  - '**/docker-compose*.yml'
-  - '**/docker-compose*.yaml'
-  - '**/compose*.yml'
-  - '**/compose*.yaml'
-  - '**/compose*.yml'
-  - '**/compose*.yaml'
-
-script:
-  - '**/scripts/**'
-  - '**/*.sh'
-
-yaml:
-  - '**/*.yaml'
-  - '**/*.yml'
-
-module:
-  - '**/modules/**'
-
+# Terraform providers
 provider:
-  - '**/providers.tf'
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/providers.tf'
+      - '**/terraform.tf'
 
+# Terraform modules
+module:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'terraform/modules/**/*'
+
+# Terraform outputs
 output:
-  - '**/outputs.tf'
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/outputs.tf'
 
-application:
-  - '**/applications/**'
+# Kubernetes related files
+kubernetes:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.yaml'
+      - '**/*.yml'
+      - 'kubernetes_cluster/**/*'
+      - 'google_kubernetes_engine/**/*'
 
+# ArgoCD related files
+argocd:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'argocd/**/*'
+
+# Google Cloud Platform
+gcp:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'google_kubernetes_engine/**/*'
+      - 'scripts/setup-gcp-project.sh'
+
+# Istio service mesh
+istio:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'argocd/applications/istio.yaml'
+      - 'argocd/applications/istio-gateway.yaml'
+      - 'argocd/infrastructure/argocd-config/argocd-gateway.yaml'
+      - 'argocd/infrastructure/argocd-config/argocd-virtualservice.yaml'
+
+# Cert-Manager
+cert-manager:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'argocd/applications/cert-manager.yaml'
+      - 'argocd/infrastructure/cert-manager/**/*'
+      - 'argocd/infrastructure/argocd-config/argocd-certificate.yaml'
+      - 'argocd/infrastructure/argocd-config/cluster-issuer.yaml'
+
+# Microservices
+microservices:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'argocd/applications/whispr-microservices.yaml'
+      - 'argocd/microservices/**/*'
+
+# Infrastructure
+infrastructure:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'argocd/infrastructure/**/*'
+      - 'terraform/**/*'
+      - 'kubernetes_cluster/**/*'
+      - 'google_kubernetes_engine/**/*'
+
+# Cloud topics
+cloud:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'google_kubernetes_engine/**/*'
+      - 'kubernetes_cluster/**/*'
+
+# Automation & CI/CD
+automation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**/*'
+      - 'scripts/**/*'
+      - 'Justfile'
+
+# Docker & containers
+docker:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docker/**/*'
+      - '**/Dockerfile*'
+      - '**/*docker*'
+
+# YAML configuration
+yaml:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.yaml'
+      - '**/*.yml'
+
+# Shell or automation scripts
+script:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'scripts/**/*'
+      - '**/*.sh'
+      - 'Justfile'
+
+# Setup & bootstrap
 setup:
-  - '**/setup*'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'scripts/setup-gcp-project.sh'
+      - 'argocd/root.yaml'
 
+# Project management
 project:
-  - '**/project*'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'README.md'
+      - '**/*.md'
+      - 'Justfile'
 
+# Security & certificates
 security:
-  - '**/certificate*'
-  - '**/issuer*'
-  - '**/cert-manager*'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'argocd/infrastructure/argocd-config/argocd-certificate.yaml'
+      - 'argocd/infrastructure/argocd-config/cluster-issuer.yaml'
+      - 'argocd/applications/cert-manager.yaml'
+      - 'argocd/infrastructure/cert-manager/**/*'
+
+# K8s applications
+application:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'argocd/applications/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,9 +12,8 @@ kubernetes:
   - '**/istio*.yaml'
   - '**/cert-manager*.yaml'
   - '**/microservices/**'
-  - '**/*.yaml'
   - '!**/docker/**'
-
+  # Removed overly broad '**/*.yaml' pattern to avoid false positives
 gcp:
   - '**/google_kubernetes_engine/**'
   - '**/setup-gcp-project.sh'
@@ -26,15 +25,21 @@ argocd:
 
 istio:
   - '**/istio*.yaml'
+  - '**/istio*.yml'
 
 cert-manager:
   - '**/cert-manager*.yaml'
+  - '**/cert-manager*.yml'
 
 microservices:
   - '**/microservices/**'
 
 docker:
   - '**/docker/**'
+  - '**/docker-compose*.yml'
+  - '**/docker-compose*.yaml'
+  - '**/compose*.yml'
+  - '**/compose*.yaml'
   - '**/compose*.yml'
 
 script:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,49 @@
+name: "Create GitHub Labels"
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  create-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create labels for technologies and topics
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'terraform', color: '5C4EE5', description: 'Terraform IaC' },
+              { name: 'kubernetes', color: '326CE5', description: 'Kubernetes resources' },
+              { name: 'gcp', color: '4285F4', description: 'Google Cloud Platform' },
+              { name: 'argocd', color: 'EF7B4D', description: 'ArgoCD deployment' },
+              { name: 'istio', color: '466BB0', description: 'Istio service mesh' },
+              { name: 'cert-manager', color: '0078D4', description: 'Cert-Manager' },
+              { name: 'microservices', color: 'E67E22', description: 'Microservices architecture' },
+              { name: 'infrastructure', color: '6E5494', description: 'Infrastructure' },
+              { name: 'cloud', color: '00B4AB', description: 'Cloud topics' },
+              { name: 'automation', color: 'B60205', description: 'Automation & CI/CD' },
+              { name: 'docker', color: '2496ED', description: 'Docker & containers' },
+              { name: 'yaml', color: 'CB171E', description: 'YAML configuration' },
+              { name: 'script', color: 'C5DEF5', description: 'Shell or automation scripts' },
+              { name: 'setup', color: 'FBCA04', description: 'Setup & bootstrap' },
+              { name: 'project', color: '0E8A16', description: 'Project management' },
+              { name: 'security', color: 'D93F0B', description: 'Security & certificates' },
+              { name: 'provider', color: '5319E7', description: 'Terraform provider' },
+              { name: 'module', color: '1D76DB', description: 'Terraform module' },
+              { name: 'output', color: '0052CC', description: 'Terraform output' },
+              { name: 'application', color: '5319E7', description: 'K8s application' },
+            ];
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              } catch (e) {
+                if (e.status !== 422) throw e; // 422 = already exists
+              }
+            }


### PR DESCRIPTION
This pull request introduces automated labeling for pull requests and issues, as well as a workflow to ensure all relevant GitHub labels are created and kept up to date. These changes streamline the process of categorizing contributions by technology and topic, making it easier to manage and review PRs.

**Label automation and management:**

* Added a `.github/labeler.yml` configuration file that maps file patterns to labels for technologies and topics such as `terraform`, `kubernetes`, `gcp`, `argocd`, `istio`, `cert-manager`, `microservices`, `docker`, `yaml`, and more. This enables automatic labeling of PRs and issues based on changed files.
* Introduced a `labeler.yml` workflow that runs on pull request events and applies labels according to the `.github/labeler.yml` configuration using the `actions/labeler` GitHub Action.

**Label creation and maintenance:**

* Added a `labels.yml` workflow that creates and maintains a set of predefined labels with specific colors and descriptions for technologies and topics. This workflow runs on pushes to `main` and can also be triggered manually.