### PR TITLE
[WHISPR-117] Fix label creation logic to handle existing labels

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -36,24 +36,30 @@ jobs:
               { name: 'output', color: '0052CC', description: 'Terraform output' },
               { name: 'application', color: '5319E7', description: 'K8s application' },
             ];
+
             for (const label of labels) {
-              try {
-                await github.rest.issues.createLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label.name,
-                  color: label.color,
-                  description: label.description
-                if (e.status !== 422) throw e; // 422 = already exists
-                // If label exists, update its color and description to match desired state
-                await github.rest.issues.updateLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label.name,
-                  color: label.color,
-                  description: label.description
-                });
-              } catch (e) {
-                if (e.status !== 422) throw e; // 422 = already exists
-              }
+                try {
+
+                    await github.rest.issues.createLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        name: label.name,
+                        color: label.color,
+                        description: label.description
+                    });
+
+                } catch (e) {
+
+                    // 422 = already exists
+                    if (e.status !== 422) throw e;
+
+                    // If label exists, update its color and description to match desired state
+                    await github.rest.issues.updateLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        name: label.name,
+                        color: label.color,
+                        description: label.description
+                    });
+                }
             }


### PR DESCRIPTION
This pull request refactors the label management logic in the `.github/workflows/labels.yml` workflow to improve error handling and ensure that label updates are only attempted when necessary. The main change is restructuring the try/catch block to properly handle label creation and updates.

**Improvements to label creation and update logic:**

* Refactored the loop that creates labels to wrap only the label creation API call in the try block, and moved the update logic into the catch block, ensuring that label updates are only attempted if a label already exists (status 422). This prevents unnecessary update attempts and clarifies the error handling flow. [[1]](diffhunk://#diff-09793c303182c720cf0b5b29c80723b396d6f87c1642fbb7e4f9fe48cbf4560dR39-R55) [[2]](diffhunk://#diff-09793c303182c720cf0b5b29c80723b396d6f87c1642fbb7e4f9fe48cbf4560dL56-L57)