### PR TITLE
[WHISPR-115] Add istio-csr-cert-manager to integrate the two projects

### DIFF
--- a/argocd/applications/istio-csr.yaml
+++ b/argocd/applications/istio-csr.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio-csr
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2" # Deploy after cert-manager but before istio
+    argocd.argoproj.io/display-name: "Istio CSR"
+spec:
+  project: default
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager-istio-csr
+    targetRevision: v0.7.0
+    helm:
+      releaseName: cert-manager-istio-csr
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false  # cert-manager namespace should already exist
+      - ServerSideApply=true
+    managedNamespaceMetadata:
+      labels:
+        name: cert-manager

--- a/argocd/applications/istio.yaml
+++ b/argocd/applications/istio.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "2" # Deploy after cert-manager
+    argocd.argoproj.io/sync-wave: "3" # Deploy after cert-manager and istio-csr
     argocd.argoproj.io/display-name: "Istio"
 spec:
   project: default

--- a/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
@@ -10,16 +10,6 @@ spec:
   gateways:
   - argocd-gateway
   http:
-  # Autorise le challenge ACME HTTP-01 sans redirection
-  - match:
-    - uri:
-        prefix: "/.well-known/acme-challenge/"
-    route:
-    - destination:
-        host: argocd-server.argocd.svc.cluster.local
-        port:
-          number: 80
-  # Redirige tout le reste du trafic HTTP vers HTTPS
   - match:
     - uri:
         prefix: "/"


### PR DESCRIPTION
This pull request introduces the deployment of the `cert-manager-istio-csr` Helm chart via ArgoCD and updates the Istio deployment to ensure proper sequencing. Additionally, it cleans up the ArgoCD virtual service configuration by removing an obsolete HTTP-01 ACME challenge route.

**Istio CSR integration and deployment sequencing:**

* Adds a new ArgoCD `Application` manifest for deploying the `cert-manager-istio-csr` Helm chart (`argocd/applications/istio-csr.yaml`).
* Updates the Istio ArgoCD application to deploy after both `cert-manager` and `istio-csr` by incrementing the `sync-wave` annotation from "2" to "3" (`argocd/applications/istio.yaml`).

**Configuration cleanup:**

* Removes the HTTP-01 ACME challenge route from the ArgoCD virtual service, simplifying the HTTP routing configuration (`argocd/infrastructure/argocd-config/argocd-virtualservice.yaml`).