### PR TITLE
[WHISPR-115] Add an Issuer for `istio-csr`

### DIFF
--- a/argocd/applications/argocd.yaml
+++ b/argocd/applications/argocd.yaml
@@ -5,7 +5,7 @@ metadata:
   name: argocd-config
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "4" # Deployed after istio-gateway
+    argocd.argoproj.io/sync-wave: "6" # Deployed after istio-gateway
 spec:
   project: default
   source:

--- a/argocd/applications/istio-bootstrap.yaml
+++ b/argocd/applications/istio-bootstrap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio-bootstrap
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2" # Deploy before cert-manager and istio-csr
+    argocd.argoproj.io/display-name: "Istio Bootstrap Issuer"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/whispr-messenger/infrastructure
+    path: argocd/infrastructure/istio-bootstrap
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: istio-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true  # Create istio-system namespace if it doesn't exist
+      - ServerSideApply=true
+    managedNamespaceMetadata:
+      labels:
+        name: istio-system

--- a/argocd/applications/istio-csr.yaml
+++ b/argocd/applications/istio-csr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio-csr
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "2" # Deploy after cert-manager but before istio
+    argocd.argoproj.io/sync-wave: "3" # Deploy after cert-manager but before istio
     argocd.argoproj.io/display-name: "Istio CSR"
 spec:
   project: default
@@ -15,6 +15,23 @@ spec:
     targetRevision: v0.7.0
     helm:
       releaseName: cert-manager-istio-csr
+      values: |
+        app:
+          certmanager:
+            issuer:
+              name: istio-ca
+              kind: Issuer
+              group: cert-manager.io
+          tls:
+            rootCAFile: /var/run/secrets/istio-csr/ca.pem
+            istiodCertificateEnable: true
+        volumeMounts:
+          - name: root-ca
+            mountPath: /var/run/secrets/istio-csr
+        volumes:
+          - name: root-ca
+            secret:
+              secretName: istio-root-ca
   destination:
     server: https://kubernetes.default.svc
     namespace: cert-manager

--- a/argocd/applications/istio-gateway.yaml
+++ b/argocd/applications/istio-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-gateway
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "3" # Immediately after Istio control plane
+    argocd.argoproj.io/sync-wave: "5" # Immediately after Istio control plane
     argocd.argoproj.io/display-name: "Istio Ingress Gateway"
 spec:
   project: default

--- a/argocd/applications/istio.yaml
+++ b/argocd/applications/istio.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "3" # Deploy after cert-manager and istio-csr
+    argocd.argoproj.io/sync-wave: "4" # Deploy after cert-manager and istio-csr
     argocd.argoproj.io/display-name: "Istio"
 spec:
   project: default

--- a/argocd/infrastructure/istio-bootstrap/bootstrap-issuer.yaml
+++ b/argocd/infrastructure/istio-bootstrap/bootstrap-issuer.yaml
@@ -1,0 +1,109 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: istio-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: istio-ca
+  namespace: istio-system
+spec:
+  isCA: true
+  commonName: istio-ca
+  secretName: istio-ca
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  subject:
+    organizationalUnits:
+    - cert-manager
+    - cluster.local
+  issuerRef:
+    name: selfsigned
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: istio-ca
+  namespace: istio-system
+spec:
+  ca:
+    secretName: istio-ca
+---
+# Job to extract the CA certificate and create the root-ca secret for istio-csr
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-root-ca-extractor
+  namespace: istio-system
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    spec:
+      serviceAccountName: istio-root-ca-extractor
+      containers:
+      - name: extractor
+        image: bitnami/kubectl:1.28
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 256Mi
+        command:
+        - /bin/bash
+        - -c
+        - |
+          # Wait for the istio-ca secret to be available
+          echo "Waiting for istio-ca secret..."
+          kubectl wait --for=condition=Ready certificate/istio-ca -n istio-system --timeout=300s
+          
+          # Extract the CA certificate
+          echo "Extracting CA certificate..."
+          kubectl get secret istio-ca -n istio-system -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/ca.pem
+          
+          # Create the root-ca secret for istio-csr in cert-manager namespace
+          echo "Creating istio-root-ca secret in cert-manager namespace..."
+          kubectl create secret generic istio-root-ca -n cert-manager --from-file=ca.pem=/tmp/ca.pem --dry-run=client -o yaml | kubectl apply -f -
+          
+          echo "Root CA secret created successfully"
+      restartPolicy: OnFailure
+  backoffLimit: 3
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-root-ca-extractor
+  namespace: istio-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-root-ca-extractor
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "update", "patch"]
+- apiGroups: ["cert-manager.io"]
+  resources: ["certificates"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-root-ca-extractor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-root-ca-extractor
+subjects:
+- kind: ServiceAccount
+  name: istio-root-ca-extractor
+  namespace: istio-system


### PR DESCRIPTION
This pull request introduces a new "istio-bootstrap" application to automate the creation and management of Istio's certificate authority (CA) and root CA secrets, and updates the ArgoCD sync order for Istio-related components to ensure proper dependency management. It also enhances the configuration for the "istio-csr" application to use the generated root CA. These changes improve the reliability and automation of the Istio certificate provisioning process.

**Istio Bootstrap & Certificate Automation:**

* Adds a new `istio-bootstrap` ArgoCD application (`argocd/applications/istio-bootstrap.yaml`) to manage the creation of a self-signed CA, issue the Istio CA certificate, and automate extraction and distribution of the root CA secret to the appropriate namespace. This includes the necessary RBAC, job, and issuer/certificate resources (`argocd/infrastructure/istio-bootstrap/bootstrap-issuer.yaml`). [[1]](diffhunk://#diff-af90ca380c0e9e37cf519120adc3a16cfeb5f71fce2acff7c84e6c021baa7119R1-R28) [[2]](diffhunk://#diff-52511a6e734fb58e83b90b30d42a840d7981ae6c967d294433ee9b541a7ea806R1-R109)

**Sync Order Updates for ArgoCD Applications:**

* Updates the `sync-wave` annotations across Istio-related ArgoCD applications to ensure correct deployment order: `istio-bootstrap` (2), `istio-csr` (3), `istio` (4), `istio-gateway` (5), and `argocd-config` (6). This guarantees that certificate infrastructure is in place before dependent components deploy. [[1]](diffhunk://#diff-c184a8a3b6785f16fb7e85cd5cb0e76772169af7866b748ddff350e89e4637e1L8-R8) [[2]](diffhunk://#diff-f037d7a1e61112c4a1a89560b0511e36a12d5671825c3daea435d64700789979L8-R8) [[3]](diffhunk://#diff-a5bc14c4ed22963d26677cfad1f0b0aaa1dd3503775a173420f5770e9f635324L7-R7) [[4]](diffhunk://#diff-552725d19d79310ce372e533a09dfcb92269935527ff4e058f3354e6cee8fe4bL8-R8)

**istio-csr Application Configuration:**

* Updates the Helm values for the `istio-csr` application to reference the generated root CA secret and configure the issuer, ensuring it uses the new automated CA infrastructure.