### PR TITLE
[WHISPR-115] Route ACME challenges to solver service in VirtualService

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-gateway.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-gateway.yaml
@@ -8,15 +8,13 @@ spec:
   selector:
     istio: ingressgateway
   servers:
-  # HTTP server to redirect to HTTPS
+  # HTTP server (no automatic redirect - managed by VirtualService)
   - port:
       number: 80
       name: http
       protocol: HTTP
     hosts:
     - argocd.whispr.epitech-msc2026.me
-    tls:
-      httpsRedirect: true
   # HTTPS server
   - port:
       number: 443

--- a/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-virtualservice.yaml
@@ -10,8 +10,30 @@ spec:
   gateways:
   - argocd-gateway
   http:
+  # ACME challenges must be served over HTTP - route to solver service
+  - match:
+    - uri:
+        prefix: "/.well-known/acme-challenge/"
+    route:
+    - destination:
+        host: cm-acme-http-solver-m98ls.argocd.svc.cluster.local
+        port:
+          number: 8089
+  # Redirect all other HTTP traffic to HTTPS
   - match:
     - uri:
         prefix: "/"
     redirect:
       scheme: https
+  # HTTPS traffic routing to ArgoCD
+  - match:
+    - uri:
+        prefix: "/"
+      headers:
+        ":scheme":
+          exact: "https"
+    route:
+    - destination:
+        host: argocd-server.argocd.svc.cluster.local
+        port:
+          number: 80


### PR DESCRIPTION
This pull request updates the ArgoCD gateway and virtual service configuration to better handle HTTP/HTTPS traffic and support ACME HTTP-01 challenges for certificate issuance. The most important changes are grouped below:

**Ingress Gateway Configuration:**

* Removed automatic HTTP-to-HTTPS redirection from the `argocd-gateway.yaml` HTTP server, delegating redirect logic to the VirtualService instead.

**VirtualService Routing Logic:**

* Added a dedicated route for ACME HTTP-01 challenges, ensuring requests to `/.well-known/acme-challenge/` are handled by the ACME solver service.
* Configured all other HTTP traffic to be redirected to HTTPS at the VirtualService level, centralizing redirect logic.
* Added explicit routing for HTTPS traffic to forward requests to the ArgoCD server service, ensuring correct handling of secure connections.