### PR TITLE
[WHISPR-115] Use regional static IP for NGINX Ingress LoadBalancer

### DIFF
--- a/argocd/infrastructure/nginx-ingress/values.yaml
+++ b/argocd/infrastructure/nginx-ingress/values.yaml
@@ -1,7 +1,7 @@
 controller:
   service:
     type: LoadBalancer
-    loadBalancerIP: "34.54.120.120"  # Our static IP
+    loadBalancerIP: "34.34.178.239"  # Regional static IP
     annotations:
       cloud.google.com/load-balancer-type: "External"
   config:


### PR DESCRIPTION
- Create regional static IP (34.34.178.239) instead of global
- LoadBalancer services require regional IPs, not global ones
- Update NGINX Ingress configuration to use new IP

DNS Update Required:
argocd.whispr.epitech-msc2026.me -> 34.34.178.239