### PR TITLE
[WHISPR-115] Change ArgoCD Ingress to HTTP backend protocol

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-ingress.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-ingress.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    nginx.ingress.kubernetes.io/grpc-backend: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
- Remove GRPC annotations that may cause 502 errors
- Use standard HTTP backend protocol instead
- ArgoCD web UI works fine with HTTP backend