### PR TITLE
[WHISPR-115] Update GitHub OAuth to use actual whispr-team

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -39,4 +39,4 @@ data:
         orgs:
         - name: whispr-messenger
           teams:
-          - developers  # You can specify a specific team or remove this to allow all org members
+          - whispr-team  # Your actual team slug

--- a/argocd/infrastructure/argocd-config/argocd-github-oauth-secret.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-github-oauth-secret.yaml
@@ -12,11 +12,9 @@ metadata:
 type: Opaque
 data:
   # Base64 encoded GitHub OAuth App Client ID
-  # Replace 'YOUR_GITHUB_CLIENT_ID' with your actual GitHub OAuth App Client ID
-  dex.github.clientId: WU9VUl9HSVRIVUJfQ0xJRU5UX0lE  # This is base64 for 'YOUR_GITHUB_CLIENT_ID'
+  dex.github.clientId: T3YyM2xpS0hQVEZISkJRZEJVMkQ=  # Ov23liKHPTFHJBQdBU2D
   # Base64 encoded GitHub OAuth App Client Secret  
-  # Replace 'YOUR_GITHUB_CLIENT_SECRET' with your actual GitHub OAuth App Client Secret
-  dex.github.clientSecret: WU9VUl9HSVRIVUJfQ0xJRU5UX1NFQ1JFVA==  # This is base64 for 'YOUR_GITHUB_CLIENT_SECRET'
+  dex.github.clientSecret: MTliNWY3YmNmZTA4MTk4Yzk0MGQ3NTg2NTgyOWVmNjI4YzA2YTczZA==  # 19b5f7bcfe08198c940d75865829ef628c06a73d
   # For OIDC configuration (if needed)
-  oidc.github.clientId: WU9VUl9HSVRIVUJfQ0xJRU5UX0lE
-  oidc.github.clientSecret: WU9VUl9HSVRIVUJfQ0xJRU5UX1NFQ1JFVA==
+  oidc.github.clientId: T3YyM2xpS0hQVEZISkJRZEJVMkQ=
+  oidc.github.clientSecret: MTliNWY3YmNmZTA4MTk4Yzk0MGQ3NTg2NTgyOWVmNjI4YzA2YTczZA==

--- a/argocd/infrastructure/argocd-config/argocd-rbac-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-rbac-cm.yaml
@@ -14,8 +14,8 @@ data:
   
   # CSV format for RBAC policies
   policy.csv: |
-    # Admin access for whispr-messenger org members
-    g, whispr-messenger:developers, role:admin
+    # Admin access for whispr-messenger org members in whispr-team
+    g, whispr-messenger:whispr-team, role:admin
     g, whispr-messenger, role:developer
     
     # Custom developer role with specific permissions


### PR DESCRIPTION
- Change team reference from 'developers' to 'whispr-team'
- Update RBAC configuration to match actual GitHub team structure