### PR TITLE
[WHISPR-115] Remove OIDC configuration, use only Dex for GitHub OAuth

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -18,15 +18,6 @@ data:
   # Application instance label key
   application.instanceLabelKey: argocd.argoproj.io/instance
   
-  # GitHub OAuth configuration via OIDC
-  oidc.config: |
-    name: GitHub
-    issuer: https://github.com
-    clientId: $oidc.github.clientId
-    clientSecret: $oidc.github.clientSecret
-    requestedScopes: ["read:user", "user:email", "read:org"]
-    requestedIDTokenClaims: {"groups": {"essential": true}}
-  
   # Dex configuration for GitHub OAuth
   dex.config: |
     connectors:

--- a/argocd/infrastructure/argocd-config/argocd-github-oauth-secret.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-github-oauth-secret.yaml
@@ -11,10 +11,7 @@ metadata:
     app.kubernetes.io/part-of: argocd
 type: Opaque
 data:
-  # Base64 encoded GitHub OAuth App Client ID
+  # Base64 encoded GitHub OAuth App Client ID for Dex
   dex.github.clientId: T3YyM2xpS0hQVEZISkJRZEJVMkQ=  # Ov23liKHPTFHJBQdBU2D
-  # Base64 encoded GitHub OAuth App Client Secret  
+  # Base64 encoded GitHub OAuth App Client Secret for Dex  
   dex.github.clientSecret: MTliNWY3YmNmZTA4MTk4Yzk0MGQ3NTg2NTgyOWVmNjI4YzA2YTczZA==  # 19b5f7bcfe08198c940d75865829ef628c06a73d
-  # For OIDC configuration (if needed)
-  oidc.github.clientId: T3YyM2xpS0hQVEZISkJRZEJVMkQ=
-  oidc.github.clientSecret: MTliNWY3YmNmZTA4MTk4Yzk0MGQ3NTg2NTgyOWVmNjI4YzA2YTczZA==


### PR DESCRIPTION
- Remove oidc.config that was causing 404 errors with GitHub
- GitHub doesn't support OIDC directly, only OAuth via Dex
- Clean up secret to only include Dex credentials