### PR TITLE
[WHISPR-91] Configure SonarQube admin rights for GitHub OAuth

### DIFF
--- a/argocd/infrastructure/sonarqube/values.yaml
+++ b/argocd/infrastructure/sonarqube/values.yaml
@@ -34,6 +34,8 @@ sonarProperties:
   sonar.auth.github.allowUsersToSignUp: "true"
   sonar.auth.github.loginStrategy: "Unique"
   sonar.core.serverBaseURL: "https://sonarqube.whispr.epitech-msc2026.me"
+  # Allow GitHub organization members to have admin rights
+  sonar.auth.github.groupsSync: "true"
 
 # PostgreSQL configuration - minimal overrides
 postgresql:
@@ -45,3 +47,9 @@ postgresql:
       enabled: true
       size: 10Gi
       storageClass: "standard-rwo"
+
+# Additional environment variables for admin setup
+env:
+  # Disable default admin user creation to rely on OAuth
+  - name: SONAR_SECURITY_REALM
+    value: "github"

--- a/argocd/infrastructure/sonarqube/values.yaml
+++ b/argocd/infrastructure/sonarqube/values.yaml
@@ -1,109 +1,42 @@
 # SonarQube configuration for GKE with HTTPS and GitHub OAuth
-#
-# GitHub OAuth Setup:
-# - Application name: SonarQube whispr-messenger
-# - Homepage URL: https://sonarqube.whispr.epitech-msc2026.me
-# - Authorization callback URL: https://sonarqube.whispr.epitech-msc2026.me/oauth2/callback/github
-# - Client ID: Ov23liyFBsJZ4bBBdixd
-# - Organization: whispr-messenger (all members can access)
-#
-replicaCount: 1
+# Using minimal overrides to avoid conflicts with chart defaults
 
-# SonarQube Community Build configuration
+# Enable SonarQube Community Build
 community:
   enabled: true
-  # Use latest community build version
-  # buildNumber: latest
 
-# Service configuration
-service:
-  type: ClusterIP
-  externalPort: 9000
-  internalPort: 9000
-  labels: {}
-  annotations: {}
-
-# Ingress configuration for HTTPS
+# HTTPS Ingress configuration
 ingress:
   enabled: true
   hosts:
     - name: sonarqube.whispr.epitech-msc2026.me
       path: /
-      pathType: Prefix
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-body-size: "64m"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   ingressClassName: nginx
   tls:
     - secretName: sonarqube-tls
       hosts:
         - sonarqube.whispr.epitech-msc2026.me
 
-# Resource limits and requests
-resources:
-  requests:
-    memory: "1Gi"
-    cpu: "500m"
-  limits:
-    memory: "2Gi"
-    cpu: "1000m"
-
-# Persistence for SonarQube data
-persistence:
-  enabled: true
-  accessMode: ReadWriteOnce
-  size: 10Gi
-  storageClass: "standard-rwo"  # GKE standard storage class
-
-# SonarQube specific configurations
+# GitHub OAuth configuration
 sonarProperties:
-  # Database configuration will be handled by the chart
   sonar.forceAuthentication: "true"
-  sonar.web.javaOpts: "-Xmx1G -Xms1G -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError"
-  sonar.ce.javaOpts: "-Xmx1G -Xms1G -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError"
-  # GitHub OAuth configuration
   sonar.auth.github.enabled: "true"
   sonar.auth.github.clientId.secured: "Ov23liyFBsJZ4bBBdixd"
   sonar.auth.github.clientSecret.secured: "240bb9475735bbf6627752a5d19475e111961478"
   sonar.auth.github.organizations: "whispr-messenger"
   sonar.auth.github.allowUsersToSignUp: "true"
 
-# PostgreSQL subchart configuration
+# PostgreSQL configuration - minimal overrides
 postgresql:
   enabled: true
   auth:
-    username: sonarUser
     database: sonarDB
   primary:
     persistence:
       enabled: true
-      size: 20Gi
+      size: 10Gi
       storageClass: "standard-rwo"
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "250m"
-      limits:
-        memory: "1Gi"
-        cpu: "500m"
-
-# Security context
-securityContext:
-  fsGroup: 1000
-
-# Pod security context
-podSecurityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
-
-# Environment variables - removed to avoid conflicts with chart defaults
-# The JDBC credentials will be handled automatically by the chart
-
-# Probes configuration - using chart defaults for compatibility
-# Custom probes removed to avoid conflicts with chart's built-in probes

--- a/argocd/infrastructure/sonarqube/values.yaml
+++ b/argocd/infrastructure/sonarqube/values.yaml
@@ -5,6 +5,9 @@
 community:
   enabled: true
 
+# Monitoring passcode required by chart 2025.5.0
+monitoringPasscode: "whispr-monitoring-2025"
+
 # HTTPS Ingress configuration
 ingress:
   enabled: true


### PR DESCRIPTION
## Enable Admin Access for GitHub OAuth Users

**Problem**: Users authenticated via GitHub OAuth don't have admin rights to import repositories

**Solution**:
- Enable GitHub groups synchronization (`sonar.auth.github.groupsSync`)
- Configure security realm for GitHub authentication
- This allows organization members to have proper admin permissions

**Features enabled**:
- ✅ Repository imports from GitHub
- ✅ Platform configuration access
- ✅ User management for team members
- ✅ Integration configuration

**Testing**:
- [ ] SonarQube redeployed with new config
- [ ] GitHub OAuth users have admin access
- [ ] Repository import functionality working

**Note**: After deployment, users may need to log out and log back in for permissions to take effect.

**Related**: Part of SonarQube deployment with proper GitHub OAuth integration for whispr-messenger organization