### PR TITLE
[WHISPR-91] Revert to original OAuth App credentials

### DIFF
--- a/argocd/infrastructure/sonarqube/values.yaml
+++ b/argocd/infrastructure/sonarqube/values.yaml
@@ -28,8 +28,8 @@ ingress:
 sonarProperties:
   sonar.forceAuthentication: "false"
   sonar.auth.github.enabled: "true"
-  sonar.auth.github.clientId.secured: "Iv23liXhU4MJnWeaqNf8"
-  sonar.auth.github.clientSecret.secured: "44acefbc166a338a8b71e11460ac7a90945fcdf0"
+  sonar.auth.github.clientId.secured: "Ov23liyFBsJZ4bBBdixd"
+  sonar.auth.github.clientSecret.secured: "240bb9475735bbf6627752a5d19475e111961478"
   sonar.auth.github.organizations: "whispr-messenger"
   sonar.auth.github.allowUsersToSignUp: "true"
   sonar.auth.github.loginStrategy: "Unique"


### PR DESCRIPTION
## Revert GitHub Credentials for OAuth

**Problem**: Using GitHub App credentials broke both OAuth and ALM integration

**Solution**: Separate the concerns:
- ✅ **OAuth App** for user authentication: `Ov23liyFBsJZ4bBBdixd`
- ✅ **GitHub App** for ALM integration: Configure manually via SonarQube UI

**Changes**:
- Restore original OAuth App Client ID: `Ov23liyFBsJZ4bBBdixd`
- Restore original OAuth App Client Secret: `240bb9475735bbf6627752a5d19475e111961478`
- Keep webhook secret for GitHub App integration

**Next Steps**:
1. Deploy this fix to restore OAuth authentication
2. Configure ALM Integration manually in SonarQube UI using GitHub App credentials
3. Test both OAuth login and ALM functionality separately

**Related**: Fixes broken OAuth and ALM integration for whispr-messenger organization