### PR TITLE
[WHISPR-91] Fix SonarQube configuration

### DIFF
--- a/argocd/infrastructure/sonarqube/values.yaml
+++ b/argocd/infrastructure/sonarqube/values.yaml
@@ -36,9 +36,6 @@ sonarProperties:
   sonar.core.serverBaseURL: "https://sonarqube.whispr.epitech-msc2026.me"
   # Allow GitHub organization members to have admin rights
   sonar.auth.github.groupsSync: "true"
-  # GitHub Code Scanning integration (webhook secret only - ALM must be configured via web UI)
-  sonar.alm.github.app.webhookSecret.secured: "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"
-  sonar.github.security.enable: "true"
 
 # PostgreSQL configuration - minimal overrides
 postgresql:


### PR DESCRIPTION
This pull request updates the SonarQube configuration to enforce authentication and removes GitHub code scanning integration secrets. The main focus is on increasing security by requiring authentication for SonarQube access and cleaning up unused GitHub integration settings.

Authentication and security improvements:
* Enabled forced authentication in SonarQube by setting `sonar.forceAuthentication` to `"true"` in `argocd/infrastructure/sonarqube/values.yaml`.

Cleanup of GitHub integration settings:
* Removed GitHub code scanning integration secrets and the `sonar.github.security.enable` property from `sonarProperties` in `argocd/infrastructure/sonarqube/values.yaml`.