### PR TITLE
[WHISPR-121] Fix ArgoCD GitHub OAuth ConfigMap variable references

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -22,8 +22,8 @@ data:
   oidc.config: |
     name: GitHub
     issuer: https://github.com
-    clientId: $oidc.github.clientId
-    clientSecret: $oidc.github.clientSecret
+    clientId: $dex.github.clientId
+    clientSecret: $dex.github.clientSecret
     requestedScopes: ["read:user", "user:email", "read:org"]
     requestedIDTokenClaims: {"groups": {"essential": true}}
   


### PR DESCRIPTION
## 🔧 Fix ArgoCD GitHub OAuth Configuration

### Problem
ArgoCD DEX server was showing warnings about missing secret keys:
- `config referenced '$oidc.github.clientId', but key does not exist in secret`
- `config referenced '$oidc.github.clientSecret', but key does not exist in secret`

### Root Cause
Inconsistent variable references between OIDC and DEX configurations:
- OIDC config was referencing `$oidc.github.*` variables
- But the Kubernetes secret only contains `dex.github.*` keys

### Solution
✅ Aligned OIDC variable references with existing DEX secret keys:
- `$oidc.github.clientId` → `$dex.github.clientId`
- `$oidc.github.clientSecret` → `$dex.github.clientSecret`

### Impact
- 🔐 Fixes GitHub OAuth authentication in ArgoCD UI
- 🚫 Eliminates DEX server warning logs
- ✅ Ensures consistent variable naming across configurations

### Testing
- [x] Configuration syntax validated
- [x] DEX pod restart completed successfully
- [ ] OAuth login flow to be tested post-deployment

### Related
- Fixes WHISPR-121