### PR TITLE
[WHISPR-121] Remove invalid OIDC configuration for GitHub OAuth

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -18,15 +18,6 @@ data:
   # Application instance label key
   application.instanceLabelKey: argocd.argoproj.io/instance
   
-  # GitHub OAuth configuration via OIDC
-  oidc.config: |
-    name: GitHub
-    issuer: https://github.com
-    clientId: $dex.github.clientId
-    clientSecret: $dex.github.clientSecret
-    requestedScopes: ["read:user", "user:email", "read:org"]
-    requestedIDTokenClaims: {"groups": {"essential": true}}
-  
   # Dex configuration for GitHub OAuth
   dex.config: |
     connectors:


### PR DESCRIPTION
## 🔧 Fix GitHub OAuth Configuration - Part 2

### Problem
After fixing the variable references, ArgoCD was still showing errors:
```
failed to query provider "https://github.com": 404 Not Found
```

### Root Cause
GitHub doesn't expose OpenID Connect discovery endpoints at `https://github.com/.well-known/openid-configuration`. The OIDC configuration was invalid and causing 404 errors when DEX tried to discover the OpenID Connect configuration.

### Solution
✅ **Removed the invalid `oidc.config` section completely**
- GitHub OAuth with ArgoCD should only use DEX GitHub connector
- DEX handles the OAuth 2.0 flow directly without needing OIDC discovery
- This is the standard approach for GitHub integration with ArgoCD

### Technical Details
- GitHub OAuth uses OAuth 2.0, not OpenID Connect
- DEX's GitHub connector communicates directly with GitHub's OAuth endpoints
- No OIDC discovery or issuer configuration needed

### Before/After Configuration:
**Before (❌ Invalid):**
```yaml
oidc.config: |
  name: GitHub
  issuer: https://github.com  # ← This causes 404 errors
  clientId: $dex.github.clientId
  clientSecret: $dex.github.clientSecret
  # ... rest of config

dex.config: |
  connectors:
  - type: github
    # ... GitHub connector config
```

**After (✅ Correct):**
```yaml
# Only DEX configuration needed for GitHub OAuth
dex.config: |
  connectors:
  - type: github
    id: github
    name: GitHub
    config:
      clientID: $dex.github.clientId
      clientSecret: $dex.github.clientSecret
      orgs:
      - name: whispr-messenger
```

### Impact
- 🚫 Eliminates `404 Not Found` errors when accessing GitHub OAuth
- ✅ Enables proper GitHub OAuth authentication flow
- 🔐 Users can now log in using "LOG IN VIA GITHUB" button

### Testing
- [x] Configuration syntax validated
- [x] Removes conflicting OIDC configuration
- [ ] OAuth login flow to be tested post-deployment

### Related
- Continuation of WHISPR-121 GitHub OAuth fix
- Related to PR #56 (variable reference fix)