### PR TITLE
[WHISPR-121] Allow all organization members for GitHub OAuth

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -29,5 +29,5 @@ data:
         clientSecret: $dex.github.clientSecret
         orgs:
         - name: whispr-messenger
-          teams:
-          - developers  # You can specify a specific team or remove this to allow all org members
+          # teams:
+          # - developers  # Commented out to allow all org members


### PR DESCRIPTION
## 🔧 Fix GitHub OAuth Team Permissions - Final Part

### Problem
After resolving the configuration issues, users were still getting authentication failures:
```
failed to authenticate: github: user "glopez-dev" not in required orgs or teams
```

The logs showed:
```
user in org but no teams connector.type=github user=glopez-dev org=whispr-messenger
```

### Root Cause
The DEX configuration was restricting access to only members of the `developers` team within the `whispr-messenger` organization. Users who are organization members but not specifically in the `developers` team were being denied access.

### Solution
✅ **Commented out the teams restriction in the DEX GitHub connector**
- Allows all members of the `whispr-messenger` organization to access ArgoCD
- Removes the specific `developers` team requirement
- Maintains organization-level security (only org members can access)

### Configuration Change:
**Before (❌ Restrictive):**
```yaml
orgs:
- name: whispr-messenger
  teams:
  - developers  # Only developers team members
```

**After (✅ Organization-wide):**
```yaml
orgs:
- name: whispr-messenger
  # teams:
  # - developers  # Commented out to allow all org members
```

### Security Considerations
- ✅ **Organization-level security maintained**: Only `whispr-messenger` org members can access
- ✅ **Easier onboarding**: New team members get immediate access
- ✅ **Flexible**: Can be reverted to team-specific access later if needed
- ✅ **ArgoCD RBAC**: Additional access control can be managed via ArgoCD RBAC policies

### Impact
- 🔐 Enables successful GitHub OAuth authentication for all org members
- 🚫 Eliminates `user not in required orgs or teams` errors
- ✅ Users can now successfully log in via "LOG IN VIA GITHUB"
- 🎯 Completes the GitHub OAuth integration for ArgoCD

### Testing Workflow
1. ✅ Variable references fixed (PR #56)
2. ✅ Invalid OIDC configuration removed (PR #57)  
3. 🔄 Team permissions adjusted (this PR)
4. 📋 Ready for OAuth login testing

### Related PRs
- Part 1: PR #56 - Fix variable references
- Part 2: PR #57 - Remove invalid OIDC config
- Part 3: This PR - Adjust team permissions
- Resolves: WHISPR-121