### PR TITLE
[WHISPR-121] Fix OIDC issuer to point to DEX server

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -18,6 +18,15 @@ data:
   # Application instance label key
   application.instanceLabelKey: argocd.argoproj.io/instance
   
+  # OIDC configuration pointing to DEX (not directly to GitHub)
+  oidc.config: |
+    name: GitHub
+    issuer: https://argocd.whispr.epitech-msc2026.me/api/dex
+    clientId: $dex.github.clientId
+    clientSecret: $dex.github.clientSecret
+    requestedScopes: ["openid", "profile", "email", "groups"]
+    requestedIDTokenClaims: {"groups": {"essential": true}}
+  
   # Dex configuration for GitHub OAuth
   dex.config: |
     connectors:


### PR DESCRIPTION
## 🔧 Fix OIDC Token Validation - Critical OAuth Flow Fix

### Problem
After resolving DEX authentication issues, ArgoCD server was still failing to validate tokens with errors:
```
Failed to verify token: oidc: id token issued by a different provider, 
expected "https://github.com" got "https://argocd.whispr.epitech-msc2026.me/api/dex"
```

And resulting in:
```
grpc.code=Unauthenticated grpc.error="rpc error: code = Unauthenticated desc = invalid session: failed to verify the token"
```

### Root Cause Analysis
The OAuth flow with ArgoCD + DEX works as follows:
1. **User** clicks "LOG IN VIA GITHUB"
2. **DEX** handles GitHub OAuth authentication ✅ (working)
3. **DEX** issues JWT tokens with issuer `https://argocd.whispr.epitech-msc2026.me/api/dex` ✅ (working)
4. **ArgoCD** tries to validate tokens but expects issuer `https://github.com` ❌ (failing)

**The missing piece:** ArgoCD needs OIDC configuration pointing to DEX as the token issuer, not GitHub directly.

### Solution
✅ **Added OIDC configuration with correct DEX issuer**

**Technical Implementation:**
```yaml
oidc.config: |
  name: GitHub
  issuer: https://argocd.whispr.epitech-msc2026.me/api/dex  # ← Points to DEX, not GitHub
  clientId: $dex.github.clientId
  clientSecret: $dex.github.clientSecret
  requestedScopes: ["openid", "profile", "email", "groups"]
  requestedIDTokenClaims: {"groups": {"essential": true}}
```

### OAuth Flow Architecture:
```
User → ArgoCD UI → DEX → GitHub OAuth → DEX (issues token) → ArgoCD (validates DEX token) → Success! 
```

**Before (❌ Broken):**
- ArgoCD expected tokens from: `https://github.com`
- DEX issued tokens from: `https://argocd.whispr.epitech-msc2026.me/api/dex`
- **Mismatch = Authentication failure**

**After (✅ Fixed):**
- ArgoCD expects tokens from: `https://argocd.whispr.epitech-msc2026.me/api/dex`
- DEX issues tokens from: `https://argocd.whispr.epitech-msc2026.me/api/dex`
- **Match = Authentication success**

### Configuration Components:
1. **DEX Config** (already working): Handles GitHub OAuth
2. **OIDC Config** (this fix): Tells ArgoCD where to expect tokens from

### Impact
- 🔐 **Enables successful OAuth token validation**
- ✅ **Completes the GitHub OAuth integration**
- 🚫 **Eliminates token verification errors**
- 🎯 **Users can now successfully access ArgoCD post-authentication**

### Testing Workflow
1. ✅ Variable references fixed (PR #56)
2. ✅ Invalid GitHub OIDC config removed (PR #57)
3. ✅ Team permissions adjusted (PR #58)
4. 🔄 **OIDC issuer corrected (this PR)**
5. 📋 **Ready for complete OAuth testing**

### Security Considerations
- ✅ **Token validation through DEX maintains security**
- ✅ **GitHub OAuth still enforced by DEX**
- ✅ **Organization membership still required**
- ✅ **ArgoCD RBAC policies still apply**

### Related PRs
- Part 1: PR #56 - Fix variable references  
- Part 2: PR #57 - Remove invalid OIDC config
- Part 3: PR #58 - Adjust team permissions
- **Part 4: This PR - Fix OIDC issuer (CRITICAL)**
- **Resolves: WHISPR-121 GitHub OAuth Integration**