### PR TITLE
[WHISPR-121] Apply ArgoCD SSO best practices from article analysis

### DIFF
--- a/argocd/infrastructure/argocd-config/argocd-cm.yaml
+++ b/argocd/infrastructure/argocd-config/argocd-cm.yaml
@@ -18,24 +18,17 @@ data:
   # Application instance label key
   application.instanceLabelKey: argocd.argoproj.io/instance
   
-  # GitHub OAuth configuration via OIDC
-  oidc.config: |
-    name: GitHub
-    issuer: https://github.com
-    clientId: $oidc.github.clientId
-    clientSecret: $oidc.github.clientSecret
-    requestedScopes: ["read:user", "user:email", "read:org"]
-    requestedIDTokenClaims: {"groups": {"essential": true}}
-  
-  # Dex configuration for GitHub OAuth
+  # Dex configuration for GitHub OAuth (following best practices article)
   dex.config: |
     connectors:
     - type: github
       id: github
       name: GitHub
       config:
+        baseURL: https://github.com
         clientID: $dex.github.clientId
         clientSecret: $dex.github.clientSecret
+        redirectURI: https://argocd.whispr.epitech-msc2026.me/api/dex/callback
         orgs:
         - name: whispr-messenger
           # Remove teams restriction to allow all org members


### PR DESCRIPTION
## 📚 Configuration SSO selon les meilleures pratiques - Analyse d'article

### Contexte
Après analyse d'un article détaillé sur la configuration SSO dans ArgoCD, j'ai identifié que notre configuration actuelle ne suivait pas les meilleures pratiques recommandées et pourrait expliquer les problèmes persistants.

### 🔍 Problèmes identifiés dans la configuration actuelle

#### **1. Configuration DUAL OIDC/DEX non-standard**
❌ **Avant (complexe):**
```yaml
# Configuration avec OIDC ET DEX en parallèle
oidc.config: |
  name: GitHub
  issuer: https://github.com
  clientId: $oidc.github.clientId
  clientSecret: $oidc.github.clientSecret

dex.config: |
  connectors:
  - type: github
    config:
      clientID: $dex.github.clientId
      clientSecret: $dex.github.clientSecret
```

✅ **Après (standard):**
```yaml
# Configuration DEX seulement (recommandé par l'article)
dex.config: |
  connectors:
  - type: github
    config:
      baseURL: https://github.com
      clientID: $dex.github.clientId
      clientSecret: $dex.github.clientSecret
      redirectURI: https://argocd.whispr.epitech-msc2026.me/api/dex/callback
```

#### **2. Propriétés manquantes selon l'article**
L'article spécifie des propriétés essentielles qui étaient absentes :

- ❌ **Manquant** : `baseURL: https://github.com`
- ❌ **Manquant** : `redirectURI` explicite
- ❌ **Complexité** : Double gestion OIDC + DEX

### 📋 Changements appliqués selon l'article

#### **Configuration simplifiée et conforme :**
```yaml
dex.config: |
  connectors:
  - type: github
    id: github
    name: GitHub
    config:
      baseURL: https://github.com                                    # ← Ajouté (article)
      clientID: $dex.github.clientId
      clientSecret: $dex.github.clientSecret
      redirectURI: https://argocd.whispr.epitech-msc2026.me/api/dex/callback  # ← Ajouté (article)
      orgs:
      - name: whispr-messenger
```

### 🎯 Avantages de cette approche

#### **1. Simplicité architecturale**
- ✅ **Une seule méthode d'auth** : DEX seulement
- ✅ **Configuration standard** : Suit les patterns ArgoCD officiels
- ✅ **Maintenance réduite** : Moins de complexity

#### **2. Conformité aux meilleures pratiques**
- ✅ **baseURL explicite** : Évite les ambiguïtés GitHub API
- ✅ **redirectURI défini** : Callback URL explicite et sécurisé
- ✅ **Structure recommandée** : Exactement comme dans l'article

#### **3. Robustesse**
- ✅ **Moins de points de défaillance** : Un seul chemin d'auth
- ✅ **Configuration éprouvée** : Utilisée dans de nombreux déploiements
- ✅ **Debug simplifié** : Logs plus clairs

### 🔧 Architecture OAuth finale

```
User → ArgoCD UI → DEX Server → GitHub OAuth API → Callback → ArgoCD
                     ↑                    ↓
           baseURL + redirectURI    clientID + clientSecret
```

**Flow détaillé :**
1. User clique "LOGIN VIA GITHUB"
2. ArgoCD redirige vers DEX (`/api/dex/auth/github`)
3. DEX redirige vers GitHub OAuth (`baseURL`)
4. User autorise sur GitHub
5. GitHub callback vers `redirectURI`
6. DEX traite le callback et émet un token
7. User est connecté à ArgoCD

### 🚀 Impact attendu

- 🔐 **Élimination des conflits OIDC/DEX**
- ✅ **Configuration plus stable et prévisible**
- 🎯 **Alignement avec les standards de l'industrie**
- 📋 **Facilite le debugging et la maintenance**

### 🔍 Comparaison avec l'article

| Aspect | Article recommande | Notre config avant | Notre config après |
|--------|-------------------|-------------------|-------------------|
| Méthode auth | DEX seulement | OIDC + DEX | ✅ DEX seulement |
| baseURL | ✅ Requis | ❌ Manquant | ✅ Ajouté |
| redirectURI | ✅ Explicite | ❌ Implicite | ✅ Explicite |
| Complexité | Simple | Complexe | ✅ Simple |

### 🧪 Testing
1. ✅ Configuration conforme aux meilleures pratiques
2. ✅ Propriétés requises ajoutées  
3. ✅ Architecture simplifiée
4. 🔄 **Test OAuth complet à effectuer**
5. 📋 **Vérification "LOG IN VIA GITHUB" post-déploiement**

### Related
- **Resolves: WHISPR-121 GitHub OAuth Integration**  
- **Based on: Comprehensive ArgoCD SSO configuration article**
- **Follows: Industry best practices for DEX + GitHub OAuth**