### PR TITLE
[WHISPR-124] Add Discord PR notifications workflow

### DIFF
--- a/.github/workflows/discord-pr-notifications.yml
+++ b/.github/workflows/discord-pr-notifications.yml
@@ -1,0 +1,143 @@
+name: 🔔 Discord PR Notifications
+
+on:
+  pull_request:
+    types: [opened, reopened, closed, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # ================================
+  # Discord PR Notifications
+  # ================================
+  notify-discord:
+    name: Send Discord Notification
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Determine PR action details
+        id: pr_action
+        run: |
+          case "${{ github.event.action }}" in
+            "opened")
+              echo "color=3447003" >> $GITHUB_OUTPUT
+              echo "emoji=🆕" >> $GITHUB_OUTPUT
+              echo "text=opened" >> $GITHUB_OUTPUT
+              ;;
+            "reopened")
+              echo "color=16776960" >> $GITHUB_OUTPUT
+              echo "emoji=🔄" >> $GITHUB_OUTPUT
+              echo "text=reopened" >> $GITHUB_OUTPUT
+              ;;
+            "closed")
+              if [ "${{ github.event.pull_request.merged }}" == "true" ]; then
+                echo "color=65280" >> $GITHUB_OUTPUT
+                echo "emoji=✅" >> $GITHUB_OUTPUT
+                echo "text=merged" >> $GITHUB_OUTPUT
+              else
+                echo "color=16711680" >> $GITHUB_OUTPUT
+                echo "emoji=❌" >> $GITHUB_OUTPUT
+                echo "text=closed" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            "ready_for_review")
+              echo "color=3447003" >> $GITHUB_OUTPUT
+              echo "emoji=👀" >> $GITHUB_OUTPUT
+              echo "text=marked as ready for review" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "color=9936031" >> $GITHUB_OUTPUT
+              echo "emoji=📝" >> $GITHUB_OUTPUT
+              echo "text=${{ github.event.action }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Extract commit SHA
+        id: commit
+        run: |
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Send Discord notification
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: "GitHub Actions"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-title: "${{ steps.pr_action.outputs.emoji }} Pull Request ${{ steps.pr_action.outputs.text }}"
+          embed-description: |
+            **PR #${{ github.event.pull_request.number }}**: ${{ github.event.pull_request.title }}
+            
+            🌿 Branch: \`${{ github.event.pull_request.head.ref }}\` → \`${{ github.event.pull_request.base.ref }}\`
+            👤 Author: [${{ github.event.pull_request.user.login }}](${{ github.event.pull_request.user.html_url }})
+            📊 Changes: +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
+            📦 Commit: \`${{ steps.commit.outputs.short_sha }}\`
+            
+            [View Pull Request →](${{ github.event.pull_request.html_url }})
+          embed-url: ${{ github.event.pull_request.html_url }}
+          embed-color: ${{ steps.pr_action.outputs.color }}
+          embed-thumbnail-url: ${{ github.event.pull_request.user.avatar_url }}
+          embed-footer-text: "infrastructure • whispr-messenger"
+          embed-footer-icon-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-timestamp: ${{ github.event.pull_request.created_at }}
+
+  # ================================
+  # Review notifications
+  # ================================
+  notify-review:
+    name: Send Review Notification
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_review'
+
+    steps:
+      - name: Determine review details
+        id: review_action
+        run: |
+          case "${{ github.event.review.state }}" in
+            "approved")
+              echo "color=65280" >> $GITHUB_OUTPUT
+              echo "emoji=✅" >> $GITHUB_OUTPUT
+              echo "text=approved" >> $GITHUB_OUTPUT
+              ;;
+            "changes_requested")
+              echo "color=16711680" >> $GITHUB_OUTPUT
+              echo "emoji=❌" >> $GITHUB_OUTPUT
+              echo "text=requested changes" >> $GITHUB_OUTPUT
+              ;;
+            "commented")
+              echo "color=9936031" >> $GITHUB_OUTPUT
+              echo "emoji=💬" >> $GITHUB_OUTPUT
+              echo "text=commented" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "color=9936031" >> $GITHUB_OUTPUT
+              echo "emoji=📝" >> $GITHUB_OUTPUT
+              echo "text=${{ github.event.review.state }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Send review notification
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: "GitHub Actions"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-title: "${{ steps.review_action.outputs.emoji }} PR Review ${{ steps.review_action.outputs.text }}"
+          embed-description: |
+            **PR #${{ github.event.pull_request.number }}**: ${{ github.event.pull_request.title }}
+            
+            👤 Reviewer: [${{ github.event.review.user.login }}](${{ github.event.review.user.html_url }})
+            👤 Author: [${{ github.event.pull_request.user.login }}](${{ github.event.pull_request.user.html_url }})
+            
+            [View Review →](${{ github.event.review.html_url }})
+          embed-url: ${{ github.event.review.html_url }}
+          embed-color: ${{ steps.review_action.outputs.color }}
+          embed-thumbnail-url: ${{ github.event.review.user.avatar_url }}
+          embed-footer-text: "infrastructure • whispr-messenger"
+          embed-footer-icon-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-timestamp: ${{ github.event.review.submitted_at }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md
+
+## Git/GitHub Standards
+
+### Branch Naming Convention
+
+All branches must follow this format:
+```
+WHISPR-<number>-<descriptive-name>
+```
+
+**Examples:**
+- `WHISPR-123-add-user-authentication`
+- `WHISPR-456-fix-payment-gateway`
+- `WHISPR-789-update-api-documentation`
+
+### Commit Message Format
+
+Commits must follow a combination of **Gitmoji + Conventional Commit** format in English:
+
+```
+<gitmoji> <type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+**Rules:**
+- Only ONE emoji at the beginning (the gitmoji)
+- No other emojis anywhere in the commit message
+- Write in English
+- Keep the subject line under 72 characters
+- Use imperative mood ("add" not "added" or "adds")
+
+**Example:**
+```
+✨ feat(auth): add OAuth2 authentication flow
+
+Implement Google and GitHub OAuth providers
+Add token refresh mechanism
+
+WHISPR-123
+```
+
+### Gitmoji Reference
+
+Use these emojis for commits:
+
+| Emoji | Code | Type | When to Use |
+|-------|------|------|-------------|
+| ✨ | `:sparkles:` | feat | Introduce new features |
+| 🐛 | `:bug:` | fix | Fix a bug |
+| 📝 | `:memo:` | docs | Add or update documentation |
+| 🎨 | `:art:` | style | Improve structure/format of code |
+| ♻️ | `:recycle:` | refactor | Refactor code |
+| ⚡️ | `:zap:` | perf | Improve performance |
+| ✅ | `:white_check_mark:` | test | Add or update tests |
+| 🔧 | `:wrench:` | chore | Add or update configuration files |
+| 🔨 | `:hammer:` | build | Add or update build scripts |
+| 👷 | `:construction_worker:` | ci | Add or update CI configuration |
+| 🚀 | `:rocket:` | deploy | Deploy stuff |
+| 🔒️ | `:lock:` | security | Fix security issues |
+| 🔥 | `:fire:` | remove | Remove code or files |
+| 🚚 | `:truck:` | move | Move or rename files |
+| 📦️ | `:package:` | deps | Add or update dependencies |
+| ⬆️ | `:arrow_up:` | upgrade | Upgrade dependencies |
+| ⬇️ | `:arrow_down:` | downgrade | Downgrade dependencies |
+| 💄 | `:lipstick:` | ui | Add or update UI/styles |
+| 🚧 | `:construction:` | wip | Work in progress |
+| 🩹 | `:adhesive_bandage:` | hotfix | Simple fix for non-critical issue |
+| 🔀 | `:twisted_rightwards_arrows:` | merge | Merge branches |
+| ⏪️ | `:rewind:` | revert | Revert changes |
+
+### Conventional Commit Types
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation only changes
+- **style**: Code style changes (formatting, missing semicolons, etc.)
+- **refactor**: Code change that neither fixes a bug nor adds a feature
+- **perf**: Performance improvement
+- **test**: Adding or updating tests
+- **build**: Changes to build system or dependencies
+- **ci**: Changes to CI configuration
+- **chore**: Other changes that don't modify src or test files
+
+### Pull Request Title Format
+
+PR titles must follow this format:
+```
+[WHISPR-<number>] <descriptive title>
+```
+
+**Rules:**
+- NO emojis in PR titles
+- Include Jira ticket number in brackets at the start
+- Use clear, descriptive titles
+- Write in English
+
+**Examples:**
+- `[WHISPR-123] Add user authentication system`
+- `[WHISPR-456] Fix payment gateway timeout issue`
+- `[WHISPR-789] Update API documentation for v2 endpoints`
+
+### Quick Reference
+
+**Branch:**
+```
+WHISPR-123-add-feature-name
+```
+
+**Commit:**
+```
+✨ feat(module): add new feature description
+```
+
+**Pull Request:**
+```
+[WHISPR-123] Add new feature description
+```


### PR DESCRIPTION
## 🔔 Discord PR Notifications Workflow

This PR adds a comprehensive GitHub Actions workflow for sending Discord notifications on pull request events and reviews.

### 📋 Features

- **PR Event Notifications**: Automatically notifies Discord when PRs are:
  - 🆕 Opened
  - 🔄 Reopened  
  - ✅ Merged
  - ❌ Closed
  - 👀 Ready for review

- **Review Notifications**: Sends notifications for PR reviews:
  - ✅ Approved
  - ❌ Changes requested
  - 💬 Commented

### 🎨 Rich Discord Embeds

- Color-coded notifications based on action type
- Comprehensive PR information (author, changes, commit SHA)
- Direct links to PR and reviews
- Repository identification in footer
- Proper timestamp tracking

### 🔧 Configuration

- Uses `DISCORD_WEBHOOK_URL` secret for Discord integration
- Skips notifications for draft PRs
- Minimal required permissions (`contents: read`, `pull-requests: read`)

### 📝 Implementation Notes

- Adapted from auth-service workflow
- Updated footer text to reflect infrastructure repository
- Follows GitHub Actions best practices
- Compatible with existing Discord notification patterns

Fixes: WHISPR-124