### PR TITLE
[WHISPR-125] Setup Redis cluster via ArgoCD with Helm on GKE

### DIFF
--- a/argocd/applications/redis.yaml
+++ b/argocd/applications/redis.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: redis
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  sources:
+  - repoURL: https://charts.bitnami.com/bitnami
+    chart: redis
+    targetRevision: 22.0.7
+    helm:
+      valueFiles:
+        - $values/argocd/infrastructure/redis/values.yaml
+
+  - repoURL: 'https://github.com/whispr-messenger/infrastructure.git'
+    targetRevision: main
+    ref: values
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: redis
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - Replace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/infrastructure/redis/README.md
+++ b/argocd/infrastructure/redis/README.md
@@ -1,0 +1,131 @@
+# Redis Cluster Configuration
+
+This directory contains the configuration for deploying Redis cluster on the Whispr infrastructure using ArgoCD and Helm.
+
+## Overview
+
+- **Chart**: Bitnami Redis v22.0.7
+- **Redis Version**: 8.2.1
+- **Architecture**: Master-Replica with Sentinel
+- **Namespace**: `redis`
+- **High Availability**: Yes (1 master + 2 replicas + sentinel)
+
+## Architecture
+
+The Redis deployment uses the following architecture:
+
+- **Master**: 1 instance for write operations
+- **Replicas**: 2 instances for read operations and failover
+- **Sentinel**: Provides automatic failover and monitoring
+- **Persistence**: Enabled with 8Gi PVC per instance
+
+## Configuration Highlights
+
+### Security
+- Authentication enabled with auto-generated passwords
+- Pod Security Context with non-root user (1001)
+- Security capabilities dropped
+- Protected mode enabled
+
+### Performance
+- Memory limit: 512Mi per instance
+- CPU limit: 500m per instance
+- AOF persistence enabled
+- LRU eviction policy
+- TCP keepalive optimizations
+
+### High Availability
+- Master-replica replication
+- Sentinel-based failover
+- Pod Disruption Budget (minAvailable: 1)
+- Anti-affinity rules (handled by Bitnami chart)
+
+## Usage
+
+### Connection Information
+
+The Redis cluster can be accessed using the following service endpoints:
+
+- **Master (Read/Write)**: `redis.redis.svc.cluster.local:6379`
+- **Replica (Read-only)**: `redis-replica.redis.svc.cluster.local:6379`
+- **Sentinel**: `redis-sentinel.redis.svc.cluster.local:26379`
+
+### Authentication
+
+The Redis password is auto-generated and stored in the secret `redis`:
+
+```bash
+# Get the Redis password
+kubectl get secret redis -n redis -o jsonpath="{.data.redis-password}" | base64 -d
+```
+
+### Connection Examples
+
+#### From within the cluster:
+```bash
+# Connect to master
+redis-cli -h redis.redis.svc.cluster.local -p 6379 -a $(kubectl get secret redis -n redis -o jsonpath="{.data.redis-password}" | base64 -d)
+
+# Connect to replica
+redis-cli -h redis-replica.redis.svc.cluster.local -p 6379 -a $(kubectl get secret redis -n redis -o jsonpath="{.data.redis-password}" | base64 -d)
+```
+
+#### For applications:
+```yaml
+# Environment variables for application pods
+env:
+- name: REDIS_HOST
+  value: "redis.redis.svc.cluster.local"
+- name: REDIS_PORT
+  value: "6379"
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: redis
+      key: redis-password
+```
+
+## Monitoring
+
+Currently, monitoring is disabled. To enable:
+
+1. Uncomment the metrics section in `values.yaml`
+2. Set `metrics.enabled: true`
+3. Set `serviceMonitor.enabled: true`
+
+## Persistence
+
+Each Redis instance has:
+- **Storage**: 8Gi PersistentVolume
+- **Access Mode**: ReadWriteOnce
+- **Backup**: AOF + RDB snapshots
+- **Retention**: Follows Redis configuration (save points)
+
+## Troubleshooting
+
+### Check Redis status:
+```bash
+kubectl get pods -n redis
+kubectl logs -n redis redis-node-0
+```
+
+### Test connectivity:
+```bash
+kubectl exec -it redis-node-0 -n redis -- redis-cli ping
+```
+
+### Check replication:
+```bash
+kubectl exec -it redis-node-0 -n redis -- redis-cli info replication
+```
+
+### Sentinel status:
+```bash
+kubectl exec -it redis-node-0 -n redis -- redis-cli -p 26379 sentinel masters
+```
+
+## Resources
+
+- [Bitnami Redis Chart Documentation](https://github.com/bitnami/charts/tree/main/bitnami/redis)
+- [Redis Configuration Reference](https://redis.io/topics/config)
+- [Redis Sentinel Documentation](https://redis.io/topics/sentinel)

--- a/argocd/infrastructure/redis/values.yaml
+++ b/argocd/infrastructure/redis/values.yaml
@@ -143,6 +143,8 @@ redis:
     appendfsync everysec
     
     # Set maximum memory and eviction policy
+    # maxmemory is set to 384mb to provide headroom below the 512Mi container memory limit,
+    # allowing for Redis overhead, AOF persistence, and OS usage to prevent OOM kills.
     maxmemory 384mb
     maxmemory-policy allkeys-lru
     
@@ -161,9 +163,9 @@ redis:
     databases 16
     
     # Save configuration for persistence
-    save 900 1
-    save 300 10
-    save 60 10000
+    save 900 1      # Save the DB if at least 1 key changed in 900 seconds
+    save 300 10     # Save the DB if at least 10 keys changed in 300 seconds
+    save 60 10000   # Save the DB if at least 10,000 keys changed in 60 seconds
 
 ## Network Policy
 networkPolicy:

--- a/argocd/infrastructure/redis/values.yaml
+++ b/argocd/infrastructure/redis/values.yaml
@@ -1,0 +1,210 @@
+# Redis configuration for Whispr project
+# Based on Bitnami Redis Helm chart v22.0.7
+
+## Global settings
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+  defaultStorageClass: ""
+  redis:
+    password: "" # Will be auto-generated if empty
+
+## Redis Architecture
+# Available options: standalone, replication
+architecture: replication
+
+## Redis Authentication
+auth:
+  enabled: true
+  sentinel: true
+  # Password will be auto-generated and stored in secret
+  # existingSecret: "redis-secret"
+  # existingSecretPasswordKey: "redis-password"
+
+## Redis Master configuration
+master:
+  count: 1
+  
+  ## Resource configuration
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  
+  ## Persistence configuration
+  persistence:
+    enabled: true
+    storageClass: ""
+    size: 8Gi
+    accessModes:
+      - ReadWriteOnce
+  
+  ## Pod Security Context
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+    runAsNonRoot: true
+  
+  ## Container Security Context
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1001
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+## Redis Replica configuration
+replica:
+  replicaCount: 2
+  
+  ## Resource configuration
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  
+  ## Persistence configuration
+  persistence:
+    enabled: true
+    storageClass: ""
+    size: 8Gi
+    accessModes:
+      - ReadWriteOnce
+  
+  ## Pod Security Context
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+    runAsNonRoot: true
+  
+  ## Container Security Context
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1001
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+## Redis Sentinel configuration
+sentinel:
+  enabled: true
+  
+  ## Resource configuration
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "100m"
+    limits:
+      memory: "128Mi"
+      cpu: "200m"
+  
+  ## Pod Security Context
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+    runAsNonRoot: true
+  
+  ## Container Security Context
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1001
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+## Redis configuration
+redis:
+  ## Redis configuration file content
+  configmap: |
+    # Redis configuration optimized for caching and session storage
+    # Enable AOF persistence
+    appendonly yes
+    appendfsync everysec
+    
+    # Set maximum memory and eviction policy
+    maxmemory 384mb
+    maxmemory-policy allkeys-lru
+    
+    # Optimize for performance
+    tcp-keepalive 300
+    timeout 0
+    
+    # Security settings
+    protected-mode yes
+    
+    # Logging
+    loglevel notice
+    
+    # Performance tuning
+    tcp-backlog 511
+    databases 16
+    
+    # Save configuration for persistence
+    save 900 1
+    save 300 10
+    save 60 10000
+
+## Network Policy
+networkPolicy:
+  enabled: false
+  
+## Pod Disruption Budget
+pdb:
+  create: true
+  minAvailable: 1
+
+## Service Monitor for Prometheus
+serviceMonitor:
+  enabled: false
+  # Enable when Prometheus is deployed
+  # enabled: true
+  # namespace: monitoring
+  # interval: 30s
+  # scrapeTimeout: 10s
+
+## Metrics configuration
+metrics:
+  enabled: false
+  # Enable when monitoring is setup
+  # enabled: true
+  # resources:
+  #   requests:
+  #     memory: "64Mi"
+  #     cpu: "50m"
+  #   limits:
+  #     memory: "128Mi"
+  #     cpu: "100m"
+  # serviceMonitor:
+  #   enabled: true
+  #   namespace: monitoring
+
+## Pod Annotations
+commonAnnotations:
+  "whispr.dev/component": "cache"
+  "whispr.dev/team": "platform"
+
+## Pod Labels
+commonLabels:
+  app.kubernetes.io/part-of: "whispr"
+  app.kubernetes.io/component: "cache"


### PR DESCRIPTION
## Summary

This PR implements the Redis cluster setup for WHISPR-125, deploying a high-availability Redis cluster on GKE using ArgoCD and the Bitnami Helm chart.

## Changes

### 🎯 ArgoCD Application
- **Added**: `argocd/applications/redis.yaml`
- **Chart**: Bitnami Redis v22.0.7 (Redis 8.2.1)
- **Sync Wave**: 2 (after cert-manager)
- **Namespace**: `redis` (auto-created)

### ⚙️ Configuration
- **Added**: `argocd/infrastructure/redis/values.yaml`
- **Architecture**: Master-replica with Sentinel (1 master + 2 replicas)
- **High Availability**: Automatic failover via Sentinel
- **Security**: Authentication enabled, non-root containers, security contexts
- **Persistence**: 8Gi PVC per instance with AOF + RDB snapshots
- **Resources**: 512Mi RAM, 500m CPU limits per instance

### 📚 Documentation
- **Added**: `argocd/infrastructure/redis/README.md`
- Complete setup and troubleshooting guide
- Connection examples and authentication instructions
- Architecture overview and monitoring setup

## Technical Details

### Redis Configuration Highlights
- **Persistence**: AOF + RDB with optimized save points
- **Memory Management**: 384MB max with LRU eviction
- **Performance**: TCP keepalive, optimized backlog
- **Security**: Protected mode, authentication required

### High Availability Setup
- **Master**: 1 instance for writes
- **Replicas**: 2 instances for reads and failover
- **Sentinel**: Monitors cluster health and handles failover
- **PDB**: Ensures minimum availability during updates

### Connection Endpoints
- **Master**: `redis.redis.svc.cluster.local:6379`
- **Replica**: `redis-replica.redis.svc.cluster.local:6379` 
- **Sentinel**: `redis-sentinel.redis.svc.cluster.local:26379`

## Deployment

The Redis cluster will be automatically deployed by ArgoCD when this PR is merged:

1. ArgoCD detects the new application in `applications/`
2. Syncs the Redis application with sync wave 2
3. Deploys the Bitnami Redis chart with our custom values
4. Creates the `redis` namespace and all required resources

## Testing

✅ **Helm Template**: Validated manifest generation  
✅ **Kubectl Dry-run**: Confirmed resource validity  
✅ **Chart Version**: Latest stable Bitnami Redis (22.0.7)  
✅ **Configuration**: Security and performance optimizations verified  

## Compliance

- ✅ Follows ArgoCD app-of-apps pattern
- ✅ Consistent with existing infrastructure setup
- ✅ Security best practices applied
- ✅ Resource limits and requests configured
- ✅ Comprehensive documentation provided

## Related

- **JIRA**: WHISPR-125 - Setup cluster Redis via ArgoCD avec Helm sur GKE
- **Epic**: Infrastructure setup for Whispr microservices
- **Dependencies**: Requires ArgoCD and cert-manager (sync wave 1)

## Post-Merge Tasks

- [ ] Verify ArgoCD sync and deployment
- [ ] Validate Redis cluster health
- [ ] Update microservices to use Redis endpoints
- [ ] Enable monitoring when Prometheus is deployed