### PR TITLE
[WHISPR-91] Fix SonarQube PostgreSQL storage sync issue

### DIFF
--- a/argocd/infrastructure/sonarqube/values.yaml
+++ b/argocd/infrastructure/sonarqube/values.yaml
@@ -45,5 +45,5 @@ postgresql:
   primary:
     persistence:
       enabled: true
-      size: 10Gi
+      size: 20Gi
       storageClass: "standard-rwo"


### PR DESCRIPTION
## Problem
The SonarQube application in ArgoCD was showing an OutOfSync status due to a mismatch between the PostgreSQL PersistentVolumeClaim storage size and the configuration in values.yaml.

## Root Cause
- Current PVC was created with **20Gi** storage
- values.yaml specified **10Gi** storage  
- PVCs cannot be reduced in size once created, causing permanent drift

## Solution
Updated the PostgreSQL storage configuration in `argocd/infrastructure/sonarqube/values.yaml` to match the current PVC size of **20Gi**.

## Changes
- Updated `postgresql.primary.persistence.size` from `10Gi` to `20Gi`

## Testing
After this change, ArgoCD should be able to sync the SonarQube application without issues.

## Verification Steps
1. Merge this PR
2. Wait for ArgoCD to detect the change
3. Verify SonarQube application shows "Synced" status in ArgoCD UI

Closes WHISPR-91