### PR TITLE
[WHISPR-91] Fix ArgoCD sync by ignoring StatefulSet volumeClaimTemplates drift

### DIFF
--- a/argocd/applications/sonarqube.yaml
+++ b/argocd/applications/sonarqube.yaml
@@ -34,3 +34,9 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+  - group: apps
+    kind: StatefulSet
+    name: sonarqube-postgresql
+    jsonPointers:
+    - /spec/volumeClaimTemplates


### PR DESCRIPTION
## Problem
The SonarQube application in ArgoCD continues to show OutOfSync status even after fixing the PostgreSQL storage configuration. This is due to StatefulSet immutability constraints.

## Root Cause Analysis
- **StatefulSet created**: September 30, 2025 (4 days ago)
- **Issue**: `volumeClaimTemplates` field in StatefulSets is **immutable** after creation
- **Result**: ArgoCD detects configuration drift but cannot apply changes to immutable fields
- **Impact**: Persistent OutOfSync status despite working application

## Solution
Added `ignoreDifferences` configuration to the SonarQube ArgoCD application to explicitly ignore drift in the PostgreSQL StatefulSet's `volumeClaimTemplates` field.

## Changes
```yaml
ignoreDifferences:
- group: apps
  kind: StatefulSet
  name: sonarqube-postgresql
  jsonPointers:
  - /spec/volumeClaimTemplates
```

## Benefits
- ✅ Resolves persistent ArgoCD OutOfSync status
- ✅ Maintains existing working configuration (20Gi storage)
- ✅ Prevents unnecessary sync attempts on immutable fields
- ✅ Follows ArgoCD best practices for handling StatefulSet immutability

## Testing
After this change, the SonarQube application should show "Synced" status in ArgoCD while maintaining full functionality.

## Verification Steps
1. Merge this PR
2. Wait for ArgoCD to detect the change
3. Verify SonarQube application shows "Synced" status in ArgoCD UI
4. Confirm SonarQube application remains healthy and functional

Closes WHISPR-91