### PR TITLE
[WHISPR-134] Add platform team access infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 gcp-terraform-key.json
 .terraform
 terraform-sa-key.json
+platform-engineers-key.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+Instructions for coding agents working on the Whispr infrastructure.
+
 ## Git/GitHub Standards
 
 ### Branch Naming Convention
@@ -119,3 +121,119 @@ WHISPR-123-add-feature-name
 ```
 [WHISPR-123] Add new feature description
 ```
+
+## Infrastructure Development Principles
+
+### Simplicity and Minimalism
+- Always prefer the simplest and most direct solution
+- Remove unnecessary elements: no example files, informational scripts, or redundant documentation
+- Avoid premature abstractions
+
+### Professional Approach
+- No emojis in code, documentation, or scripts (except in commit messages as per Gitmoji standard)
+- Clear and direct messages without embellishments
+- Compliance with enterprise standards
+
+### Separation of Responsibilities
+- Administration scripts in `scripts/`
+- Kubernetes manifests in `argocd/infrastructure/`
+- GitOps configuration in `argocd/applications/`
+- Terraform in `terraform/`
+
+## Project Structure
+
+```
+infrastructure/
+├── argocd/
+│   ├── applications/          # ArgoCD applications (generic names)
+│   ├── infrastructure/        # Kubernetes manifests by component
+│   └── microservices/         # Microservices deployments
+├── scripts/                   # Automation scripts only
+├── terraform/                 # Infrastructure as Code
+└── Justfile                   # Central task automation
+```
+
+## Development Conventions
+
+### ArgoCD Applications
+- Generic names (e.g., `rbac`, not `platform-engineers-rbac`)
+- Appropriate sync waves: 1-10
+- Auto-sync and self-healing enabled
+- Source pointing to `argocd/infrastructure/`
+
+### Shell Scripts
+- Functional only, not informational
+- Messages without emojis
+- Permissions verified with `chmod +x`
+- Clear environment variables
+
+### Documentation
+- Concise README (maximum 100 lines)
+- No multiple READMEs per folder
+- Direct instructions without excessive explanations
+- No example files (.example)
+
+### Justfile
+- Commands organized by groups (`[group('name')]`)
+- Clear and consistent task names
+- No superfluous log messages
+- Explicit dependencies between tasks
+
+## Essential Commands
+
+### Initial Setup
+```bash
+just setup-gcp-project <PROJECT_ID>    # GCP configuration
+just setup-platform-access             # Team access (admin)
+```
+
+### Common Operations
+```bash
+just --list                             # See all commands
+just verify-access                      # Test access (team)
+just apply-app <app>                    # Deploy ArgoCD app
+just clean                              # Clean temporary files
+```
+
+### Debugging
+```bash
+just get-pods-prod                      # Pods in production
+just get-istio-authz                    # Istio policies
+just cluster-info                       # Cluster info
+```
+
+## Strict Rules
+
+### Do
+- Keep generic and scalable structure
+- Test changes with `just --list`
+- Verify RBAC permissions after modifications
+- Use appropriate ArgoCD sync waves
+
+### Don't
+- Example or demonstration files
+- Scripts that only display information
+- Detailed READMEs in each subfolder
+- Emojis in any file except commit messages
+- Team-specific ArgoCD applications
+
+### Deployment
+- Always via GitOps (ArgoCD)
+- Modifications = Git push = Automatic deployment
+- No manual `kubectl apply` in production
+- Rollback via git revert
+
+## Cluster Information
+
+- **Name:** whispr-messenger
+- **Zone:** europe-west1-b
+- **Project:** whispr-messenger-472716
+- **Prod namespace:** whispr-prod
+- **Dev namespace:** platform-dev
+
+## Security
+
+- Team service account: `platform-engineers`
+- Key rotation every 90 days
+- Principle of least privilege
+- Never commit credentials to git

--- a/Justfile
+++ b/Justfile
@@ -4,5 +4,98 @@ default:
 # Setup GCP credentials and project (requires PROJECT_ID as argument)
 [group('gcp')]
 setup-gcp project_id:
-    chmod +x scripts/setup-gcp.sh
+    chmod +x scripts/setup-gcp-project.sh
     ./scripts/setup-gcp-project.sh {{project_id}}
+
+# Create ArgoCD static IP
+[group('gcp')]
+create-argocd-ip:
+    chmod +x scripts/create-argocd-ip.sh
+    ./scripts/create-argocd-ip.sh
+
+# Show current cluster information
+[group('info')]
+cluster-info:
+    chmod +x scripts/show-cluster-info.sh
+    ./scripts/show-cluster-info.sh
+
+# Create platform engineers service account (admin only)
+[group('platform')]
+create-platform-sa:
+    chmod +x scripts/platform-engineers/create-platform-engineers-sa.sh
+    ./scripts/platform-engineers/create-platform-engineers-sa.sh
+
+# Apply platform engineers RBAC (admin only) 
+[group('platform')]
+apply-platform-rbac:
+    kubectl apply -f argocd/infrastructure/rbac/platform-engineers-rbac.yaml
+
+# Setup complete platform engineers access (admin only)
+[group('platform')]
+setup-platform-access: create-platform-sa apply-platform-rbac
+
+# Verify kubectl access (for team members)
+[group('platform')]
+verify-access:
+    chmod +x scripts/platform-engineers/verify-kubectl-access.sh
+    ./scripts/platform-engineers/verify-kubectl-access.sh
+
+# Apply specific ArgoCD application
+[group('argocd')]
+apply-app app:
+    kubectl apply -f argocd/applications/{{app}}.yaml
+
+# Apply all ArgoCD applications
+[group('argocd')]
+apply-all-apps:
+    kubectl apply -f argocd/applications/
+
+# Apply ArgoCD root app (app of apps pattern)
+[group('argocd')]
+apply-root:
+    kubectl apply -f argocd/root.yaml
+
+# Sync specific ArgoCD application
+[group('argocd')]
+sync-app app:
+    argocd app sync {{app}}
+
+# Get ArgoCD application status
+[group('argocd')]
+app-status app:
+    argocd app get {{app}}
+
+# Port-forward to ArgoCD server (for local access)
+[group('argocd')]
+argocd-port-forward:
+    kubectl port-forward svc/argocd-server -n argocd 8080:443
+
+# Get all pods in whispr-prod namespace
+[group('debug')]
+get-pods-prod:
+    kubectl get pods -n whispr-prod
+
+# Get all Istio authorization policies
+[group('debug')]
+get-istio-authz:
+    kubectl get authorizationpolicies -A
+
+# Describe a specific pod
+[group('debug')]
+describe-pod pod namespace='whispr-prod':
+    kubectl describe pod {{pod}} -n {{namespace}}
+
+# Get logs from a pod
+[group('debug')]
+logs pod namespace='whispr-prod' follow='false':
+    @if [ "{{follow}}" = "true" ]; then \
+        kubectl logs {{pod}} -n {{namespace}} -f; \
+    else \
+        kubectl logs {{pod}} -n {{namespace}}; \
+    fi
+
+# Clean up generated files
+[group('clean')]
+clean:
+    rm -f scripts/platform-engineers/platform-engineers-key.json
+    rm -f scripts/*.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-# Infrastructure
+# Infrastructure Whispr
+
+Infrastructure pour le projet Whispr avec GitOps et Kubernetes.
+
+## Quick Start
+
+```bash
+# Configuration initiale GCP
+just setup-gcp-project
+
+# Accès équipe plateforme
+just setup-platform-access
+
+# Voir toutes les commandes
+just --list
+```
+
+## Structure
+
+```
+infrastructure/
+├── argocd/                    # Configuration GitOps
+│   ├── applications/          # Applications ArgoCD
+│   ├── infrastructure/        # Infrastructure managée
+│   └── microservices/         # Microservices deployments
+├── scripts/                   # Scripts d'automation
+├── terraform/                 # Infrastructure as Code
+└── Justfile                   # Task automation
+```
+
+## Applications ArgoCD
+
+| Application | Description | Sync Wave |
+|-------------|-------------|-----------|
+| `rbac` | Permissions et contrôles d'accès | 1 |
+| `argocd` | ArgoCD self-management | 2 |
+| `cert-manager` | Certificats TLS automatiques | 3 |
+| `nginx-ingress` | Ingress controller | 4 |
+| `redis` | Cache et sessions | 5 |
+| `sonarqube` | Qualité de code | 6 |
+| `whispr-microservices` | Application principale | 10 |
+
+### Workflow GitOps :
+
+1. **Modification** : Push code dans git
+2. **Auto-sync** : ArgoCD détecte les changements
+3. **Déploiement** : Application dans l'ordre des sync waves
+4. **Self-healing** : Correction automatique des dérives
+
+## Accès équipe
+
+**Admin :** `just setup-platform-access`  
+**Membres :** Recevoir `platform-engineers-key.json` + suivre `scripts/platform-engineers/README-kubectl-setup-team.md`
+
+## Infrastructure
+
+**Cluster GKE :** `whispr-messenger` (europe-west1-b, projet whispr-messenger-472716)
+
+**Composants :**
+- ArgoCD (GitOps)
+- Istio (Service mesh)  
+- Cert-Manager (TLS)
+- Nginx Ingress
+- Redis
+- SonarQube

--- a/argocd/applications/rbac.yaml
+++ b/argocd/applications/rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rbac
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1" # Deploye tot - permissions fondamentales
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  
+  source:
+    repoURL: https://github.com/whispr-messenger/infrastructure
+    targetRevision: HEAD
+    path: argocd/infrastructure/rbac
+    
+  destination:
+    server: https://kubernetes.default.svc
+    
+  syncPolicy:
+    automated:
+      prune: true # Supprime les ressources supprimées du git
+      selfHeal: true # Auto-correction si modification manuelle
+      allowEmpty: false # Ne sync pas si le dossier est vide
+    syncOptions:
+      - CreateNamespace=true # Crée les namespaces si nécessaire
+      - ServerSideApply=true # Kubernetes gère les conflits
+    retry: # Retry avec backoff
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/infrastructure/rbac/platform-engineers-rbac.yaml
+++ b/argocd/infrastructure/rbac/platform-engineers-rbac.yaml
@@ -1,0 +1,220 @@
+# RBAC pour l'équipe Platform Engineering - Accès partagé au cluster Whispr
+# Ce fichier configure les permissions Kubernetes pour l'équipe plateforme
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-dev
+  labels:
+    purpose: platform-development
+    team: platform-engineers
+    istio-injection: enabled  # Pour les tests Istio
+
+---
+# ClusterRole pour les Platform Engineers - Permissions étendues
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: platform-engineers
+rules:
+# Lecture globale sur toutes les ressources
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints", "persistentvolumeclaims", "configmaps", "secrets", "serviceaccounts"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses", "networkpolicies"]
+  verbs: ["get", "list", "watch"]
+
+# Permissions Istio - lecture et modification pour tests
+- apiGroups: ["security.istio.io"]
+  resources: ["authorizationpolicies", "peerauthentications"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+- apiGroups: ["networking.istio.io"]
+  resources: ["virtualservices", "destinationrules", "gateways", "serviceentries"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+- apiGroups: ["install.istio.io"]
+  resources: ["istiooperators"]
+  verbs: ["get", "list", "watch"]
+
+# ArgoCD resources - pour debugging des déploiements
+- apiGroups: ["argoproj.io"]
+  resources: ["applications", "applicationsets"]
+  verbs: ["get", "list", "watch"]
+
+# Permissions étendues pour debugging
+- apiGroups: [""]
+  resources: ["events", "nodes"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: [""]
+  resources: ["pods/log", "pods/exec"]
+  verbs: ["get", "list", "create"]
+
+- apiGroups: [""]
+  resources: ["pods/portforward"]
+  verbs: ["get", "list", "create"]
+
+# Metrics et monitoring
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+
+# Namespaces management
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+
+# CRDs pour comprendre les resources custom
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+
+# RBAC pour voir les permissions
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+  verbs: ["get", "list", "watch"]
+
+---
+# ClusterRoleBinding pour l'équipe plateforme
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: platform-engineers-binding
+subjects:
+- kind: ServiceAccount
+  name: platform-engineers
+  namespace: default
+- kind: User
+  name: platform-engineers@whispr-messenger-472716.iam.gserviceaccount.com  # Service account email
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: platform-engineers
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Role pour le namespace de dev plateforme - Permissions complètes
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: platform-dev
+  name: platform-full-access
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+
+---
+# RoleBinding pour le namespace de dev plateforme
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: platform-full-access-binding
+  namespace: platform-dev
+subjects:
+- kind: ServiceAccount
+  name: platform-engineers
+  namespace: default
+- kind: User
+  name: platform-engineers@whispr-messenger-472716.iam.gserviceaccount.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: platform-full-access
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Role pour whispr-prod - Permissions étendues pour infrastructure
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: whispr-prod
+  name: platform-infrastructure-access
+rules:
+# Toutes les ressources Istio
+- apiGroups: ["security.istio.io"]
+  resources: ["*"]
+  verbs: ["*"]
+
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["*"]
+
+# Pods et services pour tests et debugging
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints", "configmaps", "serviceaccounts"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list", "watch", "update", "patch"]
+
+# Secrets pour debugging (lecture seule)
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+
+# Logs et debugging
+- apiGroups: [""]
+  resources: ["pods/log", "pods/exec", "pods/portforward", "events"]
+  verbs: ["get", "list", "create"]
+
+---
+# RoleBinding pour whispr-prod
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: platform-infrastructure-access-binding
+  namespace: whispr-prod
+subjects:
+- kind: ServiceAccount
+  name: platform-engineers
+  namespace: default
+- kind: User
+  name: platform-engineers@whispr-messenger-472716.iam.gserviceaccount.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: platform-infrastructure-access
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Role pour les autres namespaces d'infrastructure
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: argocd
+  name: platform-readonly-access
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods/log", "pods/exec", "events"]
+  verbs: ["get", "list", "create"]
+
+---
+# RoleBinding pour argocd (lecture + logs)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: platform-readonly-access-binding
+  namespace: argocd
+subjects:
+- kind: ServiceAccount
+  name: platform-engineers
+  namespace: default
+- kind: User
+  name: platform-engineers@whispr-messenger-472716.iam.gserviceaccount.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: platform-readonly-access
+  apiGroup: rbac.authorization.k8s.io

--- a/scripts/platform-engineers/README-kubectl-setup-team.md
+++ b/scripts/platform-engineers/README-kubectl-setup-team.md
@@ -1,0 +1,191 @@
+# Guide de configuration kubectl pour l'équipe plateforme
+
+Ce guide explique comment les membres de l'équipe plateforme doivent configurer leur client kubectl pour accéder au cluster GKE avec le service account partagé.
+
+## Prérequis pour l'équipe
+
+1. Avoir reçu le fichier `platform-engineers-key.json` de manière sécurisée
+2. Installer `gcloud` CLI : https://cloud.google.com/sdk/docs/install
+3. Installer `kubectl` : https://kubernetes.io/docs/tasks/tools/
+
+## Configuration étape par étape
+
+### Étape 1 : Authentification avec le service account
+
+```bash
+# 1. Placer la clé dans un endroit sécurisé
+mkdir -p ~/.config/gcloud/
+mv platform-engineers-key.json ~/.config/gcloud/
+chmod 600 ~/.config/gcloud/platform-engineers-key.json
+
+# 2. S'authentifier avec le service account
+gcloud auth activate-service-account --key-file=~/.config/gcloud/platform-engineers-key.json
+
+# 3. Définir le projet par défaut
+gcloud config set project whispr-messenger-472716
+
+# 4. Vérifier l'authentification
+gcloud auth list
+```
+
+### Étape 2 : Récupérer les credentials du cluster
+
+```bash
+# Récupérer les informations du cluster GKE
+gcloud container clusters get-credentials whispr-messenger --zone europe-west1-b
+
+# Vérifier que le contexte est configuré
+kubectl config current-context
+```
+
+### Étape 3 : Tester l'accès
+
+```bash
+# Tests de base
+kubectl get nodes
+kubectl get namespaces
+
+# Tests spécifiques aux permissions de l'équipe plateforme
+kubectl get pods -n whispr-prod
+kubectl get authorizationpolicies -n whispr-prod
+kubectl get pods -n platform-dev
+
+# Test de création (dans le namespace de dev)
+kubectl create deployment test --image=nginx -n platform-dev
+kubectl delete deployment test -n platform-dev
+```
+
+## Vérification des permissions
+
+l'équipe peut vérifier leurs permissions avec :
+
+```bash
+# Vérifier les permissions globales
+kubectl auth can-i get pods --all-namespaces
+kubectl auth can-i create authorizationpolicies -n whispr-prod
+kubectl auth can-i delete namespace argocd  # Devrait dire "no"
+
+# Vérifier les permissions par namespace
+kubectl auth can-i "*" -n platform-dev  # Devrait dire "yes"
+kubectl auth can-i create pods -n whispr-prod  # Devrait dire "yes"
+```
+
+## Ce que l'équipe peut faire
+
+### Dans le namespace `platform-dev` :
+- Créer/modifier/supprimer toutes les ressources
+- Tester ses configurations Istio en toute liberté
+- Expérimenter sans risque
+
+### Dans le namespace `whispr-prod` :
+- Voir toutes les ressources
+- Créer/modifier les politiques Istio (AuthorizationPolicy, PeerAuthentication)
+- Créer/modifier les configurations réseau Istio (VirtualService, DestinationRule)
+- Accéder aux logs pour debugging
+- Faire du port-forwarding pour tester
+
+### Globalement :
+- Voir tous les pods, services, deployments (lecture seule)
+- Accéder aux logs de debugging
+- Voir les événements Kubernetes
+- Voir les métriques
+
+## Configuration avancée (optionnelle)
+
+### Créer un alias pour simplifier
+
+```bash
+# Ajouter dans ~/.bashrc ou ~/.zshrc
+alias k='kubectl'
+alias kgp='kubectl get pods'
+alias kgs='kubectl get services'
+alias kga='kubectl get authorizationpolicies'
+
+# Pour basculer facilement entre namespaces
+alias kn-prod='kubectl config set-context --current --namespace=whispr-prod'
+alias kn-dev='kubectl config set-context --current --namespace=platform-dev'
+```
+
+### Configuration de kubectx/kubens (recommandé)
+
+```bash
+# Installation sur macOS
+brew install kubectx
+
+# Installation sur Linux
+sudo git clone https://github.com/ahmetb/kubectx /opt/kubectx
+sudo ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx
+sudo ln -s /opt/kubectx/kubens /usr/local/bin/kubens
+
+# Usage
+kubens whispr-prod  # Basculer vers whispr-prod
+kubens platform-dev  # Basculer vers platform-dev
+```
+
+## 🔐 Sécurité
+
+### Bonnes pratiques pour les membres de l'équipe :
+
+1. **Protéger la clé JSON :**
+   ```bash
+   chmod 600 ~/.config/gcloud/platform-engineers-key.json
+   ```
+
+2. **Ne jamais commiter la clé :**
+   ```bash
+   # Ajouter dans ~/.gitignore global
+   echo "*.json" >> ~/.gitignore_global
+   git config --global core.excludesfile ~/.gitignore_global
+   ```
+
+3. **Rotation régulière :**
+   - La clé doit être renouvelée tous les 90 jours
+   - Demander une nouvelle clé si compromise
+
+4. **Utiliser un namespace dédié pour les tests :**
+   - Toujours tester dans `platform-dev` d'abord
+   - Ne modifier `whispr-prod` qu'après validation
+
+## 🆘 Troubleshooting
+
+### Problème : "Unable to connect to the server"
+```bash
+# Vérifier l'authentification
+gcloud auth list
+gcloud auth activate-service-account --key-file=~/.config/gcloud/platform-engineers-key.json
+```
+
+### Problème : "Forbidden" ou permissions insuffisantes
+```bash
+# Vérifier les permissions
+kubectl auth can-i get pods -n whispr-prod
+kubectl auth whoami  # Vérifier l'identité utilisée
+```
+
+### Problème : Mauvais contexte kubectl
+```bash
+# Lister les contextes disponibles
+kubectl config get-contexts
+
+# Basculer vers le bon contexte
+kubectl config use-context gke_PROJECT_ID_europe-west1-b_whispr-cluster
+```
+
+### Problème : Clé expirée
+```bash
+# Demander une nouvelle clé à l'admin
+# Puis réactiver l'authentification
+gcloud auth activate-service-account --key-file=NEW_KEY.json
+```
+
+## 📞 Support
+
+En cas de problème, l'équipe peut :
+1. Vérifier leurs permissions : `kubectl auth can-i --list`
+2. Vérifier son identité : `kubectl auth whoami`
+3. Vérifier la connectivité : `kubectl cluster-info`
+4. Contacter l'équipe admin avec les logs d'erreur
+
+---
+
+**Note importante :** Ce service account est partagé par l'équipe plateforme. Toutes les actions sont auditées par Kubernetes.

--- a/scripts/platform-engineers/create-platform-engineers-sa.sh
+++ b/scripts/platform-engineers/create-platform-engineers-sa.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# Script pour créer un service account générique pour les ingénieurs plateforme
+# Usage: ./create-platform-engineers-sa.sh
+
+set -e
+
+# Colors for messages
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+PROJECT_ID=$(gcloud config get-value project)
+SA_NAME="platform-engineers"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+KEY_FILE="platform-engineers-key.json"
+CLUSTER_NAME="whispr-messenger"
+CLUSTER_ZONE="europe-west1-b"
+
+# Logging functions
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_info "Creating platform engineers service account on project $PROJECT_ID"
+
+# 1. Créer le service account
+log_info "Creating service account..."
+
+gcloud iam service-accounts create $SA_NAME \
+    --display-name="Platform Engineers" \
+    --description="Shared service account for platform engineering team - GKE access, monitoring, debugging"
+
+# 2. Donner les permissions IAM pour GKE
+log_info "Adding GKE permissions..."
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/container.clusterViewer"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/container.developer"
+
+# 3. Permissions pour monitoring et debugging
+log_info "Adding monitoring and logging permissions..."
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/logging.viewer"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/monitoring.viewer"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/monitoring.metricWriter"
+
+# 4. Permissions pour Cloud Storage (backup, artifacts)
+log_info "Adding storage permissions..."
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/storage.objectViewer"
+
+# 5. Permissions pour debugging avancé (optionnel)
+log_info "Adding debugging permissions..."
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/cloudtrace.agent"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/clouddebugger.agent"
+
+# 6. Créer une clé JSON
+log_info "Creating JSON key..."
+
+gcloud iam service-accounts keys create $KEY_FILE \
+    --iam-account=$SA_EMAIL
+
+# 7. Instructions d'utilisation
+cat << EOF
+
+${GREEN}Platform Engineers service account created successfully!${NC}
+
+${YELLOW}Service Account Details:${NC}
+- Name: $SA_NAME
+- Email: $SA_EMAIL
+- Key File: $KEY_FILE
+
+${YELLOW}🔐 Permissions granted:${NC}
+- GKE cluster viewer and developer access
+- Logging and monitoring (read/write)
+- Cloud Storage read access
+- Debugging and tracing capabilities
+
+${YELLOW}Usage Instructions for Engineers:${NC}
+
+1. Securely share the key file: ${GREEN}$KEY_FILE${NC}
+
+2. Each engineer should:
+   ${GREEN}# Authenticate with the service account
+   gcloud auth activate-service-account --key-file=$KEY_FILE
+   
+   # Set the project
+   gcloud config set project $PROJECT_ID
+   
+   # Get cluster credentials
+   gcloud container clusters get-credentials whispr-cluster --zone europe-west1-b
+   
+   # Test access
+   kubectl get nodes
+   kubectl get namespaces${NC}
+
+${YELLOW}Key Rotation (recommended every 90 days):${NC}
+   ${GREEN}# Create new key
+   gcloud iam service-accounts keys create new-platform-engineers-key.json --iam-account=$SA_EMAIL
+   
+   # Delete old key (after everyone has updated)
+   gcloud iam service-accounts keys delete KEY_ID --iam-account=$SA_EMAIL${NC}
+
+${YELLOW}To revoke access later:${NC}
+   ${GREEN}gcloud iam service-accounts delete $SA_EMAIL${NC}
+
+${YELLOW}📝 Team Management:${NC}
+- Share this key securely with: David, Gabriel, and other platform engineers
+- Store the key in your password manager or secure storage
+- Document who has access for audit purposes
+- Rotate keys regularly for security
+
+${YELLOW}🔒 Security Best Practices:${NC}
+- Don't commit the key file to git
+- Use secure channels to share the key
+- Each engineer should store it securely locally
+- Monitor usage in Cloud Console IAM logs
+- Rotate keys if any engineer leaves the team
+
+EOF
+
+# 8. Sécuriser le fichier et l'ajouter au gitignore
+chmod 600 $KEY_FILE
+
+# Ajouter au gitignore s'il n'y est pas déjà
+if ! grep -q "platform-engineers-key.json" ../.gitignore 2>/dev/null; then
+    echo "platform-engineers-key.json" >> ../.gitignore
+    log_info "Added key file to .gitignore"
+fi
+
+log_info "Platform Engineers service account ready!"
+log_warn "🔐 Secure the key file and share it with your team through secure channels"

--- a/scripts/platform-engineers/verify-kubectl-access.sh
+++ b/scripts/platform-engineers/verify-kubectl-access.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# Script de vérification pour David - Teste l'accès au cluster GKE
+# Usage: ./verify-kubectl-access.sh
+
+set -e
+
+# Colors for messages
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[✗]${NC} $1"
+}
+
+log_test() {
+    echo -e "${BLUE}[TEST]${NC} $1"
+}
+
+echo "Verification de l'acces au cluster GKE pour l'equipe plateforme"
+echo "================================================================="
+
+# Test 1: Vérifier l'authentification gcloud
+log_test "Vérification de l'authentification gcloud..."
+if gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q "platform-engineers"; then
+    log_info "Service account platform-engineers actif"
+else
+    log_error "Service account platform-engineers non trouvé"
+    echo "Exécutez: gcloud auth activate-service-account --key-file=platform-engineers-key.json"
+    exit 1
+fi
+
+# Test 2: Vérifier la connectivité au cluster
+log_test "Vérification de la connectivité au cluster..."
+if kubectl cluster-info >/dev/null 2>&1; then
+    log_info "Connectivité au cluster OK"
+else
+    log_error "Impossible de se connecter au cluster"
+    echo "Exécutez: gcloud container clusters get-credentials whispr-messenger --zone europe-west1-b"
+    exit 1
+fi
+
+# Test 3: Vérifier l'identité dans Kubernetes
+log_test "Vérification de l'identité Kubernetes..."
+CURRENT_USER=$(kubectl auth whoami 2>/dev/null || echo "unknown")
+if echo "$CURRENT_USER" | grep -q "platform-engineers"; then
+    log_info "Identité Kubernetes: $CURRENT_USER"
+else
+    log_warn "Identité inattendue: $CURRENT_USER"
+fi
+
+# Test 4: Permissions de base
+log_test "Test des permissions de base..."
+
+# Lecture des nodes
+if kubectl get nodes >/dev/null 2>&1; then
+    log_info "Lecture des nodes: OK"
+else
+    log_error "Impossible de lire les nodes"
+fi
+
+# Lecture des namespaces
+if kubectl get namespaces >/dev/null 2>&1; then
+    log_info "Lecture des namespaces: OK"
+else
+    log_error "Impossible de lire les namespaces"
+fi
+
+# Test 5: Permissions Istio dans whispr-prod
+log_test "Test des permissions Istio dans whispr-prod..."
+
+if kubectl auth can-i create authorizationpolicies -n whispr-prod >/dev/null 2>&1; then
+    log_info "Création AuthorizationPolicies dans whispr-prod: OK"
+else
+    log_error "Impossible de créer des AuthorizationPolicies dans whispr-prod"
+fi
+
+if kubectl auth can-i get pods -n whispr-prod >/dev/null 2>&1; then
+    log_info "Lecture des pods dans whispr-prod: OK"
+else
+    log_error "Impossible de lire les pods dans whispr-prod"
+fi
+
+# Test 6: Permissions complètes dans platform-dev
+log_test "Test des permissions dans platform-dev..."
+
+if kubectl auth can-i "*" -n platform-dev >/dev/null 2>&1; then
+    log_info "Permissions complètes dans platform-dev: OK"
+else
+    log_error "Permissions insuffisantes dans platform-dev"
+fi
+
+# Test 7: Vérifier les restrictions (doit échouer)
+log_test "Vérification des restrictions de sécurité..."
+
+if kubectl auth can-i delete namespace argocd >/dev/null 2>&1; then
+    log_error "ATTENTION: Vous pouvez supprimer des namespaces critiques!"
+else
+    log_info "Restriction sur suppression des namespaces: OK"
+fi
+
+# Test 8: Test d'accès aux logs
+log_test "Test d'accès aux logs..."
+
+if kubectl auth can-i get pods/log --all-namespaces >/dev/null 2>&1; then
+    log_info "Accès aux logs: OK"
+else
+    log_warn "Accès aux logs limité"
+fi
+
+# Résumé des namespaces accessibles
+echo ""
+echo "📂 Namespaces accessibles:"
+kubectl get namespaces --no-headers 2>/dev/null | while read ns rest; do
+    if kubectl auth can-i get pods -n "$ns" >/dev/null 2>&1; then
+        if kubectl auth can-i create pods -n "$ns" >/dev/null 2>&1; then
+            echo -e "  ${GREEN}✓${NC} $ns (lecture + écriture)"
+        else
+            echo -e "  ${YELLOW}○${NC} $ns (lecture seule)"
+        fi
+    fi
+done
+
+# Commandes utiles
+echo ""
+echo "Commandes utiles pour debuter:"
+echo "  kubectl get pods -n whispr-prod          # Voir les pods de production"
+echo "  kubectl get authorizationpolicies -A     # Voir toutes les politiques Istio"
+echo "  kubectl logs POD_NAME -n whispr-prod     # Voir les logs d'un pod"
+echo "  kubectl config set-context --current --namespace=platform-dev  # Basculer vers votre namespace"
+echo ""
+echo "Namespace recommande pour vos tests: platform-dev"
+echo "   kubectl config set-context --current --namespace=platform-dev"
+
+echo ""
+log_info "Vérification terminée! Vous pouvez commencer à travailler avec kubectl."

--- a/scripts/show-cluster-info.sh
+++ b/scripts/show-cluster-info.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Script de verification et mise a jour des configurations
+# Affiche les vraies valeurs du cluster et projet
+
+echo "Informations reelles du cluster GKE"
+echo "======================================"
+
+PROJECT_ID=$(gcloud config get-value project 2>/dev/null)
+echo "Projet GCP: $PROJECT_ID"
+
+echo ""
+echo "Clusters disponibles:"
+gcloud container clusters list --format="table(name,location,status)" 2>/dev/null
+
+echo ""
+echo "Valeurs a utiliser dans les scripts:"
+echo "  PROJECT_ID: $PROJECT_ID"
+echo "  CLUSTER_NAME: whispr-messenger"
+echo "  CLUSTER_ZONE: europe-west1-b"
+echo "  SERVICE_ACCOUNT: platform-engineers@${PROJECT_ID}.iam.gserviceaccount.com"
+
+echo ""
+echo "Fichiers mis a jour avec ces valeurs:"
+echo "  - scripts/create-platform-engineers-sa.sh"
+echo "  - scripts/grant-gke-access.sh"
+echo "  - scripts/platform-engineers-rbac.yaml"
+echo "  - scripts/README-kubectl-setup-david.md"
+echo "  - scripts/verify-kubectl-access.sh"
+
+echo ""
+echo "Prochaines etapes pour donner acces a David:"
+echo "  1. ./create-platform-engineers-sa.sh"
+echo "  2. kubectl apply -f platform-engineers-rbac.yaml"
+echo "  3. Envoyer platform-engineers-key.json à David"


### PR DESCRIPTION
## Overview

Add comprehensive platform team access infrastructure for GKE cluster management via GitOps automation.

## Changes

### ArgoCD Applications
- **`argocd/applications/rbac.yaml`**: Generic RBAC application with sync wave 1 for foundational permissions
- Auto-sync and self-healing enabled for GitOps automation

### RBAC Infrastructure  
- **`argocd/infrastructure/rbac/platform-engineers-rbac.yaml`**: Complete platform team permissions
  - ServiceAccount: `platform-engineers` with rotation-ready structure
  - ClusterRole: Comprehensive permissions for cluster management
  - ClusterRoleBinding: Team access to production and development namespaces

### Platform Team Scripts
- **`scripts/platform-engineers/create-platform-engineers-sa.sh`**: Service account creation with key management
- **`scripts/platform-engineers/verify-kubectl-access.sh`**: Access verification and troubleshooting
- **`scripts/platform-engineers/README-kubectl-setup-team.md`**: Complete team onboarding guide

### Automation Enhancement
- **`Justfile`**: Enhanced with platform team workflow commands
  - `setup-platform-access`: Complete platform setup automation
  - `verify-access`: Team access verification
  - `get-pods-prod`: Production monitoring commands

### Cluster Information Utility
- **`scripts/show-cluster-info.sh`**: Cluster status and information display

## Technical Details

- **Cluster**: whispr-messenger (europe-west1-b)
- **Project**: whispr-messenger-472716  
- **Namespaces**: whispr-prod, platform-dev
- **GitOps**: Automatic deployment via ArgoCD
- **Security**: Service account key rotation every 90 days

## Testing

```bash
# Setup platform access (admin only)
just setup-platform-access

# Team members verify access  
just verify-access

# Monitor production
just get-pods-prod
```

Related to WHISPR-134: Platform team access infrastructure