### PR TITLE
[WHISPR-126] Fix PostgreSQL metrics exporter CrashLoopBackOff

### DIFF
--- a/argocd/infrastructure/postgresql/values.yaml
+++ b/argocd/infrastructure/postgresql/values.yaml
@@ -60,21 +60,10 @@ primary:
       type: RuntimeDefault
 
 # Metrics and monitoring
+# Disabled due to compatibility issues with bitnamilegacy images
+# The metrics exporter expects secrets in a different path format
 metrics:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/postgres-exporter
-    tag: "0.16.0-debian-12-r7"
-  serviceMonitor:
-    enabled: false
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "50m"
-    limits:
-      memory: "128Mi"
-      cpu: "100m"
+  enabled: false
 
 # Backup configuration
 backup:


### PR DESCRIPTION
## Summary

- Disable PostgreSQL metrics exporter to fix CrashLoopBackOff issue
- The postgres-exporter container fails with bitnamilegacy images due to incompatible secret path

## Problem

The postgres-exporter sidecar container in the PostgreSQL pod is crashing:
```
Error: failed loading data source pass file /opt/bitnami/postgresql/secrets/password: no such file or directory
```

## Root Cause

The bitnamilegacy postgres-exporter image expects secrets at `/opt/bitnami/postgresql/secrets/password` but the secret is mounted at a different path by the Helm chart. This is a known compatibility issue with legacy Bitnami images.

## Solution

Temporarily disable metrics until we can:
1. Configure proper secret mounting for the exporter
2. Or migrate to alternative monitoring solution
3. Or use updated Bitnami images when available

## Impact

- PostgreSQL database continues to function normally
- Only metrics collection is disabled
- Can re-enable once proper configuration is in place

## Test Plan

- [ ] Verify PostgreSQL pod starts without CrashLoopBackOff
- [ ] Confirm only one container (postgresql) is running
- [ ] Test database connectivity
- [ ] Verify ArgoCD sync completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)