### PR TITLE
[WHISPR-126] Force PostgreSQL pod restart to apply metrics fix

### DIFF
--- a/argocd/infrastructure/postgresql/values.yaml
+++ b/argocd/infrastructure/postgresql/values.yaml
@@ -81,6 +81,7 @@ volumePermissions:
 commonAnnotations:
   "whispr.dev/component": "database"
   "whispr.dev/team": "platform"
+  "whispr.dev/restartedAt": "2025-10-06T18:25:00Z"
 
 # Pod Labels
 commonLabels:


### PR DESCRIPTION
## Summary

- Add restart annotation to force StatefulSet rolling update
- Ensures pod is recreated without the metrics sidecar container

## Context

After merging PR #72 that disabled metrics, ArgoCD detected the configuration change but did not automatically trigger a pod restart. The existing pod still has the crashing metrics container.

## Solution

Add a `whispr.dev/restartedAt` annotation to force a StatefulSet update, triggering a rolling restart of the pod with the new configuration (metrics disabled).

## Expected Result

- Pod will be recreated without the metrics sidecar
- PostgreSQL will be healthy with only one container running
- No more CrashLoopBackOff

## Test Plan

- [ ] Verify ArgoCD syncs the change
- [ ] Monitor pod recreation
- [ ] Confirm pod becomes Ready (1/1 instead of 1/2)
- [ ] Test database connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)