### PR TITLE
[WHISPR-126] Use podAnnotations to force PostgreSQL StatefulSet restart

### DIFF
--- a/argocd/infrastructure/postgresql/values.yaml
+++ b/argocd/infrastructure/postgresql/values.yaml
@@ -42,6 +42,10 @@ primary:
     work_mem = 4MB
     maintenance_work_mem = 128MB
 
+  # Pod annotations to force restart
+  podAnnotations:
+    whispr.dev/restartedAt: "2025-10-06T18:35:00Z"
+
   podSecurityContext:
     enabled: true
     fsGroup: 1001
@@ -81,7 +85,6 @@ volumePermissions:
 commonAnnotations:
   "whispr.dev/component": "database"
   "whispr.dev/team": "platform"
-  "whispr.dev/restartedAt": "2025-10-06T18:25:00Z"
 
 # Pod Labels
 commonLabels:


### PR DESCRIPTION
## Summary

- Move restart annotation from `commonAnnotations` to `primary.podAnnotations`
- Properly trigger StatefulSet rolling update to apply metrics fix

## Problem

The previous PR #73 added restart annotation to `commonAnnotations`, but this applies to Kubernetes resource metadata, not the pod template spec. StatefulSet didn't trigger a rolling update.

## Solution

Use `primary.podAnnotations` which applies directly to the pod template in the StatefulSet spec, forcing a rolling restart when the annotation changes.

## Expected Result

- StatefulSet detects pod template change
- Triggers rolling update of postgresql-0 pod
- New pod starts with metrics disabled (1/1 ready instead of 1/2)
- No more CrashLoopBackOff

## Test Plan

- [ ] Verify ArgoCD syncs the change
- [ ] Monitor StatefulSet for rolling update
- [ ] Confirm pod recreated with new annotations
- [ ] Verify pod reaches Ready state (1/1)
- [ ] Test database connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)