### PR TITLE
[WHISPR-136] Add Redis HA persistence to ArgoCD

### DIFF
--- a/argocd/infrastructure/argocd/README.md
+++ b/argocd/infrastructure/argocd/README.md
@@ -1,0 +1,64 @@
+# ArgoCD Helm Configuration
+
+This directory contains the Helm values configuration for ArgoCD.
+
+## Current Status
+
+ArgoCD is currently installed via Helm but not self-managed through GitOps.
+This configuration adds Redis HA persistence to prevent data loss and failover issues.
+
+## Problem Being Solved
+
+ArgoCD Redis HA was deployed without persistent storage (using emptyDir volumes).
+This causes:
+- Data loss on pod restarts
+- Failed failover attempts with "no-good-slave" errors
+- OAuth session loss
+- Cluster split-brain scenarios
+
+## Solution
+
+Enable Redis HA persistence with PersistentVolumeClaims (8Gi standard-rwo).
+
+## How to Apply
+
+### Manual Update (Current Method)
+
+```bash
+cd infrastructure/argocd/infrastructure/argocd
+
+# Upgrade ArgoCD with new values
+helm upgrade argocd argo-cd \
+  --repo https://argoproj.github.io/argo-helm \
+  --version 8.5.2 \
+  --namespace argocd \
+  --values values.yaml
+
+# Wait for Redis pods to be recreated with PVCs
+kubectl rollout status statefulset/argocd-redis-ha-server -n argocd
+
+# Verify PVCs were created
+kubectl get pvc -n argocd
+```
+
+### Expected Result
+
+- 3 PVCs created: data-argocd-redis-ha-server-0, data-argocd-redis-ha-server-1, data-argocd-redis-ha-server-2
+- Redis HA cluster with persistent storage
+- No more data loss on pod restarts
+- Proper failover behavior
+
+## Future: GitOps Self-Management
+
+To make ArgoCD fully self-managed through GitOps, we need to:
+1. Create an ArgoCD Application that manages itself
+2. Handle the bootstrap problem carefully
+3. Ensure no disruption during the transition
+
+This will be addressed in a future ticket.
+
+## Related
+
+- Jira: WHISPR-136
+- Helm Chart: argo-cd v8.5.2
+- Documentation: https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd

--- a/argocd/infrastructure/argocd/values.yaml
+++ b/argocd/infrastructure/argocd/values.yaml
@@ -1,0 +1,80 @@
+# ArgoCD Helm Chart values
+# Based on argo-cd chart v8.5.2
+
+# Redis HA configuration with persistence
+redis-ha:
+  enabled: true
+  persistentVolume:
+    enabled: true
+    size: 8Gi
+    storageClass: standard-rwo
+
+  # Resource limits for Redis
+  redis:
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 100m
+      limits:
+        memory: 512Mi
+        cpu: 200m
+
+  # Sentinel configuration
+  sentinel:
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 50m
+      limits:
+        memory: 128Mi
+        cpu: 100m
+
+# Keep existing configuration
+global:
+  domain: argocd.whispr.epitech-msc2026.me
+
+controller:
+  replicas: 1
+
+repoServer:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+
+server:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+  service:
+    type: ClusterIP
+  metrics:
+    enabled: true
+  ingress:
+    enabled: false
+
+applicationSet:
+  replicas: 2
+
+crds:
+  install: true
+
+configs:
+  params:
+    application.instanceLabelKey: argocd.argoproj.io/instance
+    server.insecure: true
+  cm:
+    url: http://localhost:8080
+    repositories: |
+      - url: https://github.com/whispr-messenger/infrastructure/
+        type: git
+        name: argocd-apps
+    policy:
+      default: role:readonly
+      csv: |
+        p, role:admin, applications, *, */*, allow
+        p, role:admin, clusters, *, *, allow
+        p, role:admin, repositories, *, *, allow
+        p, role:admin, projects, *, *, allow
+        g, argocd-admins, role:admin
+  secret:
+    argocdServerAdminPassword: $2a$10$9Qy2iWAWOh2/MgY6qniJZ.ErnKuI/.rgUv3ptJpgcu4j.KrQmo1hG


### PR DESCRIPTION
## Summary

- Add Helm values configuration for ArgoCD with Redis HA persistence
- Document manual upgrade procedure
- Prevent data loss and failover issues in Redis HA cluster

## Problem

ArgoCD Redis HA is currently deployed without persistent storage (emptyDir volumes):
- Data is lost when pods restart
- Failover attempts fail with "no-good-slave" errors
- OAuth sessions are lost
- Cluster enters split-brain state

## Solution

Enable Redis HA persistence using PersistentVolumeClaims:
```yaml
redis-ha:
  enabled: true
  persistentVolume:
    enabled: true
    size: 8Gi
    storageClass: standard-rwo
```

## Implementation Notes

**Not Fully GitOps Yet:** ArgoCD is currently installed via `helm install` and not self-managed through GitOps. This PR provides:
1. The correct Helm values configuration
2. Documentation for manual upgrade
3. Foundation for future GitOps self-management

To apply this change:
```bash
helm upgrade argocd argo-cd \
  --repo https://argoproj.github.io/argo-helm \
  --version 8.5.2 \
  --namespace argocd \
  --values argocd/infrastructure/argocd/values.yaml
```

## Expected Result

- 3 PVCs created for Redis HA (one per pod)
- Redis data persists across pod restarts
- Proper failover behavior
- No more split-brain or OAuth session loss

## Test Plan

- [ ] Review Helm values configuration
- [ ] Apply helm upgrade command
- [ ] Verify PVCs are created
- [ ] Verify Redis pods restart successfully
- [ ] Test ArgoCD OAuth login
- [ ] Verify Redis failover works correctly

## Future Work

A follow-up ticket will address full GitOps self-management of ArgoCD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves: WHISPR-136