### PR TITLE
fix(k8s/prod): unblock ArgoCD for user, scheduling, media services

### DIFF
--- a/k8s/whispr/prod/media-service/deployment.yaml
+++ b/k8s/whispr/prod/media-service/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               value: production
           readinessProbe:
             httpGet:
-              path: /media/health/ready
+              path: /v1/media/health/ready
               port: 3012
             initialDelaySeconds: 20
             periodSeconds: 10

--- a/k8s/whispr/prod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/prod/scheduling-service/deployment.yaml
@@ -66,7 +66,3 @@ spec:
     - name: grpc
       port: 50013
       targetPort: 50013
-  template:
-    spec:
-      containers:
-        - image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-5ae2655

--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               value: http://auth-service:3010/auth/.well-known/jwks.json
           readinessProbe:
             httpGet:
-              path: /user/health/ready
+              path: /v1/user/health/ready
               port: 3011
             initialDelaySeconds: 20
             periodSeconds: 10
@@ -66,7 +66,3 @@ spec:
     - name: grpc
       port: 50011
       targetPort: 50011
-  template:
-    spec:
-      containers:
-        - image: ghcr.io/whispr-messenger/user-service/user-service:sha-4a98c58


### PR DESCRIPTION
## Summary
- Remove stray \`template/spec/containers\` block that the bump-image workflow appended under the \`Service\` doc in user-service and scheduling-service deployment.yaml. This was breaking ArgoCD server-side apply diff under k8s 1.34 strict schema.
- Revert user-service readiness probe back to \`/v1/user/health/ready\` (current image still uses versioned routes).
- Revert media-service readiness probe back to \`/v1/media/health/ready\` (same reason).

## Validation
- [x] \`kubectl apply --dry-run=server\` clean on all three manifests
- [ ] ArgoCD sync succeeds after merge