### PR TITLE
fix(k8s/prod): revert user/media probes to non-versioned paths

### DIFF
--- a/k8s/whispr/prod/media-service/deployment.yaml
+++ b/k8s/whispr/prod/media-service/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               value: production
           readinessProbe:
             httpGet:
-              path: /v1/media/health/ready
+              path: /media/health/ready
               port: 3012
             initialDelaySeconds: 20
             periodSeconds: 10

--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               value: http://auth-service:3010/auth/.well-known/jwks.json
           readinessProbe:
             httpGet:
-              path: /v1/user/health/ready
+              path: /user/health/ready
               port: 3011
             initialDelaySeconds: 20
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- Revert user-service and media-service readiness probes from /v1/... back to the non-versioned paths.
- PR #163 assumed the deployed images still used versioned routes, but direct curl against the new pods shows the opposite: /media/health/ready and /user/health/ready return 200, /v1/... return 404.

## Validation
- [x] curl against new pod IPs confirms the non-versioned path is the correct one