### PR TITLE
chore(media): pin prod image to sha

### DIFF
--- a/k8s/whispr/prod/media-service/deployment.yaml
+++ b/k8s/whispr/prod/media-service/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: media-service
-          image: ghcr.io/whispr-messenger/media-service/media-service:latest
+          image: ghcr.io/whispr-messenger/media-service/media-service:sha-c0522e5
           ports:
             - name: http
               containerPort: 3012


### PR DESCRIPTION
## Summary
- Replace `:latest` tag on media-service prod deployment with `sha-c0522e5` (matches the digest currently running: `sha256:652f37d721151727766a4bce57c88201a589ed5141bf293c6b3d815a94624226`).
- Using `:latest` prevents ArgoCD from detecting drift when the underlying image changes, and kills deterministic rollbacks.

## Validation
- [x] `kubectl apply --dry-run=client` passes
- [x] SHA matches the digest of the pod currently running in `whispr-prod`
- [ ] ArgoCD sync stays Synced after merge (no pod restart expected since the digest is identical)