### PR TITLE
fix(k8s): add REDIS_HOST and REDIS_PORT to notification-service configmap

### DIFF
--- a/k8s/whispr/production/notification-service/configmap.yaml
+++ b/k8s/whispr/production/notification-service/configmap.yaml
@@ -13,3 +13,5 @@ data:
   DB_PORT: "5432"
   DB_NAME: "notification_service_db"
   JWT_JWKS_URL: "http://auth-service.whispr-prod.svc.cluster.local:3001/auth/.well-known/jwks.json"
+  REDIS_HOST: "redis.redis.svc.cluster.local"
+  REDIS_PORT: "6379"


### PR DESCRIPTION
## Summary
- Ajout de `REDIS_HOST` et `REDIS_PORT` dans le configmap `notification-service-config`
- Kubernetes injectait automatiquement `REDIS_PORT=tcp://10.2.98.184:6379`, provoquant un crash au démarrage (`String.to_integer/1` sur une URL)
- Les variables explicites pointent vers `redis.redis.svc.cluster.local:6379`

## Validation
- [x] `kubectl apply --dry-run=client` passe sur le configmap

> Note : migration complète vers Sentinel trackée dans WHISPR-677.

Closes WHISPR-676