### PR TITLE
fix(k8s): add /v1 segment to health probe paths for auth, user and media services

### DIFF
--- a/k8s/whispr/production/auth-service/deployment.yaml
+++ b/k8s/whispr/production/auth-service/deployment.yaml
@@ -109,7 +109,7 @@ spec:
           # Liveness probe - checks if the container is alive
           livenessProbe:
             httpGet:
-              path: /auth/health/live
+              path: /auth/v1/health/live
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30
@@ -119,7 +119,7 @@ spec:
           # Readiness probe - checks if the container is ready to serve traffic
           readinessProbe:
             httpGet:
-              path: /auth/health/ready
+              path: /auth/v1/health/ready
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -129,7 +129,7 @@ spec:
           # Startup probe - gives more time for initial startup
           startupProbe:
             httpGet:
-              path: /auth/health/live
+              path: /auth/v1/health/live
               port: http
             initialDelaySeconds: 15
             periodSeconds: 5

--- a/k8s/whispr/production/media-service/deployment.yaml
+++ b/k8s/whispr/production/media-service/deployment.yaml
@@ -110,7 +110,7 @@ spec:
           # Liveness probe - checks if the container is alive
           livenessProbe:
             httpGet:
-              path: /media/health/live
+              path: /media/v1/health/live
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30
@@ -120,7 +120,7 @@ spec:
           # Readiness probe - checks if the container is ready to serve traffic
           readinessProbe:
             httpGet:
-              path: /media/health/ready
+              path: /media/v1/health/ready
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -130,7 +130,7 @@ spec:
           # Startup probe - gives more time for initial startup
           startupProbe:
             httpGet:
-              path: /media/health/live
+              path: /media/v1/health/live
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/k8s/whispr/production/user-service/deployment.yaml
+++ b/k8s/whispr/production/user-service/deployment.yaml
@@ -98,7 +98,7 @@ spec:
           # Liveness probe - checks if the container is alive
           livenessProbe:
             httpGet:
-              path: /user/health/live
+              path: /user/v1/health/live
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30
@@ -108,7 +108,7 @@ spec:
           # Readiness probe - checks if the container is ready to serve traffic
           readinessProbe:
             httpGet:
-              path: /user/health/ready
+              path: /user/v1/health/ready
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -118,7 +118,7 @@ spec:
           # Startup probe - gives more time for initial startup
           startupProbe:
             httpGet:
-              path: /user/health/live
+              path: /user/v1/health/live
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- Correction des chemins de probes (liveness, readiness, startup) pour `auth-service`, `user-service` et `media-service`
- Ces services NestJS ont `enableVersioning({ type: VersioningType.URI, defaultVersion: '1' })` — toutes les routes sont préfixées `/v1/`
- Les probes pointaient vers `/*/health/*` (HTTP 404) au lieu de `/*/v1/health/*`

## Validation
- [x] `kubectl apply --dry-run=client` passe sur les trois manifests

Closes WHISPR-678