### PR TITLE
feat(argocd): install Argo Rollouts via app-of-apps pattern

### DIFF
--- a/argocd/applications/argo-rollouts.yaml
+++ b/argocd/applications/argo-rollouts.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-rollouts
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  sources:
+  - repoURL: https://argoproj.github.io/argo-helm
+    chart: argo-rollouts
+    targetRevision: 2.39.0
+    helm:
+      valueFiles:
+        - $values/helm/argo-rollouts/values.yaml
+  - repoURL: 'https://github.com/whispr-messenger/infrastructure.git'
+    targetRevision: main
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-rollouts
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/helm/argo-rollouts/values.yaml
+++ b/helm/argo-rollouts/values.yaml
@@ -1,0 +1,2 @@
+dashboard:
+  enabled: true


### PR DESCRIPTION
## Summary
- Add `argocd/applications/argo-rollouts.yaml` — Application ArgoCD pointant sur le chart officiel `argoproj.github.io/argo-helm`
- Add `helm/argo-rollouts/values.yaml` — values minimales avec le dashboard activé
- Sync wave `"1"` pour garantir l'installation avant les microservices

## Validation
- [x] `kubectl apply --dry-run=client` retourne `created (dry run)`
- [ ] ArgoCD sync succeeds
- [ ] Namespace `argo-rollouts` créé avec pods `Running`
- [ ] CRD `rollouts.argoproj.io` présente sur le cluster

Closes WHISPR-679