### PR TITLE
fix(mobile-web): update image to sha-5c30d61

### DIFF
--- a/k8s/whispr/prod/mobile-web/deployment.yaml
+++ b/k8s/whispr/prod/mobile-web/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: mobile-web
-          image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-100ea31
+          image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-5c30d61
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Update mobile-web image to `sha-5c30d61` to fix infinite loading spinner on web
- Root cause: expo-secure-store was bundled into the web build, causing `getValueWithKeyAsync is not a function` error
- Fix: use platform-specific files (storage.web.ts) so web builds only use AsyncStorage

## Related mobile-app commit
- https://github.com/whispr-messenger/mobile-app/commit/5c30d61