### PR TITLE
feat(argocd): add Kargo to app-of-apps pattern (Helm, wave 6)

### DIFF
--- a/argocd/applications/kargo.yaml
+++ b/argocd/applications/kargo.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  project: default
+  sources:
+  - repoURL: https://charts.kargo.io
+    chart: kargo
+    targetRevision: 1.4.1
+    helm:
+      valueFiles:
+        - $values/helm/kargo/values.yaml
+  - repoURL: 'https://github.com/whispr-messenger/infrastructure.git'
+    targetRevision: main
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kargo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/helm/kargo/values.yaml
+++ b/helm/kargo/values.yaml
@@ -1,0 +1,18 @@
+api:
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    tls:
+      - hosts:
+          - kargo.whispr.epitech.beer
+        secretName: kargo-tls
+    rules:
+      - host: kargo.whispr.epitech.beer
+        paths:
+          - path: /
+            pathType: Prefix


### PR DESCRIPTION
## Summary
- Add `argocd/applications/kargo.yaml` — ArgoCD Application in sync-wave 6, namespace `kargo`, with `CreateNamespace=true`
- Add `helm/kargo/values.yaml` — Helm values enabling the Kargo API ingress on `kargo.whispr.epitech.beer` with cert-manager (`letsencrypt-prod`)

## Validation
- [x] `kubectl apply --dry-run=client -f argocd/applications/kargo.yaml` — clean
- [ ] ArgoCD sync succeeds
- [ ] Kargo pods Running in namespace `kargo`

Closes WHISPR-710