### PR TITLE
feat(vault): configure Vault credentials for Kargo (policy, VaultAuth, secrets)

### DIFF
--- a/k8s/kargo/vault-auth.yaml
+++ b/k8s/kargo/vault-auth.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: kargo-vault-auth
+  namespace: kargo
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  vaultConnectionRef: default
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: kargo
+    serviceAccount: kargo-sa
+    audiences:
+      - vault

--- a/k8s/kargo/vault-git-credentials.yaml
+++ b/k8s/kargo/vault-git-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: kargo-git-credentials
+  namespace: kargo
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  vaultAuthRef: kargo-vault-auth
+  mount: kv
+  type: kv-v2
+  path: kargo/git-credentials
+  destination:
+    name: kargo-git-credentials
+    create: true
+  refreshAfter: 1h

--- a/k8s/kargo/vault-registry-credentials.yaml
+++ b/k8s/kargo/vault-registry-credentials.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: kargo-registry-credentials
+  namespace: kargo
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  vaultAuthRef: kargo-vault-auth
+  mount: kv
+  type: kv-v2
+  path: kargo/registry-credentials
+  destination:
+    name: kargo-registry-credentials
+    create: true
+  refreshAfter: 1h

--- a/k8s/vault-config-operator/custom-resources/kubernetes-auth-roles.yaml
+++ b/k8s/vault-config-operator/custom-resources/kubernetes-auth-roles.yaml
@@ -161,3 +161,23 @@ spec:
     targetNamespaces:
       - arc-runners
   tokenTTL: 3600
+---
+# kargo
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: KubernetesAuthEngineRole
+metadata:
+  name: kargo
+  namespace: vault-config-operator-system
+spec:
+  authentication:
+    path: kubernetes
+    role: vco-admin
+  path: kubernetes
+  policies:
+    - kargo-policy
+  targetServiceAccounts:
+    - kargo-sa
+  targetNamespaces:
+    targetNamespaces:
+      - kargo
+  tokenTTL: 3600

--- a/k8s/vault-config-operator/custom-resources/policies.yaml
+++ b/k8s/vault-config-operator/custom-resources/policies.yaml
@@ -186,3 +186,19 @@ spec:
     path "kv/data/whispr/shared/github-arc" {
       capabilities = ["read"]
     }
+---
+# kargo
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Policy
+metadata:
+  name: kargo-policy
+  namespace: vault-config-operator-system
+spec:
+  authentication:
+    path: kubernetes
+    role: vco-admin
+  type: acl
+  policy: |
+    path "kv/data/kargo/*" {
+      capabilities = ["read"]
+    }


### PR DESCRIPTION
## Summary
- Add `kargo-policy` in `k8s/vault-config-operator/custom-resources/policies.yaml` — grants read on `kv/data/kargo/*`
- Add `kargo` `KubernetesAuthEngineRole` in `kubernetes-auth-roles.yaml` — binds `kargo-sa` in namespace `kargo`
- Create `k8s/kargo/vault-auth.yaml` — `VaultAuth` for the kargo namespace
- Create `k8s/kargo/vault-git-credentials.yaml` — `VaultStaticSecret` → Secret `kargo-git-credentials` (path `kargo/git-credentials`)
- Create `k8s/kargo/vault-registry-credentials.yaml` — `VaultStaticSecret` → Secret `kargo-registry-credentials` (path `kargo/registry-credentials`)

## Validation
- [x] `kubectl apply --dry-run=client -f k8s/kargo/` — clean
- [x] `kubectl apply --dry-run=client -f k8s/vault-config-operator/custom-resources/policies.yaml` — clean
- [x] `kubectl apply --dry-run=client -f k8s/vault-config-operator/custom-resources/kubernetes-auth-roles.yaml` — clean
- [ ] VSO creates and maintains secrets in namespace `kargo`

Closes WHISPR-711