### PR TITLE
feat(kargo): configure OIDC authentication via Dex (GitHub org whispr-messenger)

### DIFF
--- a/helm/kargo/values.yaml
+++ b/helm/kargo/values.yaml
@@ -16,3 +16,15 @@ api:
         paths:
           - path: /
             pathType: Prefix
+
+oidc:
+  enabled: true
+  issuerURL: https://argocd.whispr.epitech.beer/api/dex
+  clientID: kargo
+  clientSecretSecretRef:
+    name: kargo-oidc-secret
+    key: clientSecret
+
+rbac:
+  adminRoles:
+    - github.com:whispr-messenger

--- a/k8s/argocd-config/argocd-cm.yaml
+++ b/k8s/argocd-config/argocd-cm.yaml
@@ -32,3 +32,9 @@ data:
         orgs:
         - name: whispr-messenger
           # Remove teams restriction to allow all org members
+    staticClients:
+    - id: kargo
+      name: Kargo
+      redirectURIs:
+      - https://kargo.whispr.epitech.beer/auth/callback
+      secretEnv: DEX_KARGO_CLIENT_SECRET

--- a/k8s/kargo/vault-oidc-secret.yaml
+++ b/k8s/kargo/vault-oidc-secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: kargo-oidc-secret
+  namespace: kargo
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  vaultAuthRef: kargo-vault-auth
+  mount: kv
+  type: kv-v2
+  path: kargo/oidc
+  destination:
+    name: kargo-oidc-secret
+    create: true
+  refreshAfter: 1h


### PR DESCRIPTION
## Summary
- Add a static Dex client `kargo` in `k8s/argocd-config/argocd-cm.yaml` with `redirectURI` to `kargo.whispr.epitech.beer/auth/callback` and `secretEnv: DEX_KARGO_CLIENT_SECRET`
- Update `helm/kargo/values.yaml` — enable OIDC (issuer: Dex, clientID: kargo, clientSecret from VSO secret) and grant admin role to `github.com:whispr-messenger` org
- Create `k8s/kargo/vault-oidc-secret.yaml` — `VaultStaticSecret` pulling `kv/kargo/oidc` from Vault → Secret `kargo-oidc-secret` (no secret in Git)

## Validation
- [x] `kubectl apply --dry-run=client -f k8s/argocd-config/argocd-cm.yaml` — clean
- [x] `kubectl apply --dry-run=client -f k8s/kargo/vault-oidc-secret.yaml` — clean
- [ ] Members of whispr-messenger org can log in to Kargo UI via GitHub

Closes WHISPR-712