### PR TITLE
feat(vault): generate DEX_KARGO_CLIENT_SECRET in vault-bootstrap-job

### DIFF
--- a/k8s/vault/vault-bootstrap-job.yaml
+++ b/k8s/vault/vault-bootstrap-job.yaml
@@ -267,4 +267,20 @@ spec:
                 fi
               fi
 
+              ####################################################################################################
+              # Kargo OIDC client secret (one-time)
+              # Stored at two paths:
+              #   kv/argocd/secret  → key DEX_KARGO_CLIENT_SECRET (injected into argocd-dex-server via VSO)
+              #   kv/kargo/oidc     → key clientSecret (injected into kargo namespace via VSO)
+              ####################################################################################################
+              if ! vault kv get -field=DEX_KARGO_CLIENT_SECRET kv/argocd/secret >/dev/null 2>&1; then
+                echo "Generating Kargo OIDC client secret..."
+                KARGO_CLIENT_SECRET=$(openssl rand -base64 32 | tr -d '\n')
+                vault kv patch kv/argocd/secret DEX_KARGO_CLIENT_SECRET="$KARGO_CLIENT_SECRET"
+                vault kv put kv/kargo/oidc clientSecret="$KARGO_CLIENT_SECRET"
+                echo "Kargo OIDC client secret generated and stored"
+              else
+                echo "Kargo OIDC client secret already exists in Vault"
+              fi
+
               echo "Vault bootstrap completed. Microservice roles, policies and auth roles are managed by Vault Config Operator CRs."


### PR DESCRIPTION
## Summary
- Add an idempotent block in `k8s/vault/vault-bootstrap-job.yaml` that generates a random OIDC client secret for the Kargo Dex static client
- Stores it at `kv/argocd/secret` under key `DEX_KARGO_CLIENT_SECRET` (consumed by `argocd-dex-server` via VSO)
- Stores the same value at `kv/kargo/oidc` under key `clientSecret` (consumed by VSO in the `kargo` namespace via `kargo-oidc-secret`)
- Idempotent: skips generation if the key already exists in Vault

## Validation
- [x] `kubectl apply --dry-run=client -f k8s/vault/vault-bootstrap-job.yaml` — clean
- [ ] Job runs successfully and secrets appear at both Vault paths

Closes WHISPR-718