### PR TITLE
fix(argocd): correct Kargo Helm chart repository URL

### DIFF
--- a/argocd/applications/kargo.yaml
+++ b/argocd/applications/kargo.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   sources:
-  - repoURL: https://charts.kargo.io
+  - repoURL: https://akuity.github.io/kargo-charts
     chart: kargo
     targetRevision: 1.4.1
     helm:


### PR DESCRIPTION
## Summary
- Fix incorrect Helm chart repository URL for Kargo
- Replace `https://charts.kargo.io` (inexistant) par `https://akuity.github.io/kargo-charts` (repo officiel)

## Validation
- [x] `kubectl apply --dry-run=client -f argocd/applications/kargo.yaml` — clean
- [ ] ArgoCD `ComparisonError` résolu