### PR TITLE
fix(vault): handle missing kv/argocd/secret path when storing Kargo OIDC secret

### DIFF
--- a/k8s/vault/vault-bootstrap-job.yaml
+++ b/k8s/vault/vault-bootstrap-job.yaml
@@ -276,7 +276,11 @@ spec:
               if ! vault kv get -field=DEX_KARGO_CLIENT_SECRET kv/argocd/secret >/dev/null 2>&1; then
                 echo "Generating Kargo OIDC client secret..."
                 KARGO_CLIENT_SECRET=$(openssl rand -base64 32 | tr -d '\n')
-                vault kv patch kv/argocd/secret DEX_KARGO_CLIENT_SECRET="$KARGO_CLIENT_SECRET"
+                if vault kv get kv/argocd/secret >/dev/null 2>&1; then
+                  vault kv patch kv/argocd/secret DEX_KARGO_CLIENT_SECRET="$KARGO_CLIENT_SECRET"
+                else
+                  vault kv put kv/argocd/secret DEX_KARGO_CLIENT_SECRET="$KARGO_CLIENT_SECRET"
+                fi
                 vault kv put kv/kargo/oidc clientSecret="$KARGO_CLIENT_SECRET"
                 echo "Kargo OIDC client secret generated and stored"
               else


### PR DESCRIPTION
## Summary
- Fix `CrashLoopBackOff` du `vault-bootstrap-job` : `vault kv patch` retournait 404 car `kv/argocd/secret` n'existait pas encore
- Ajout d'une vérification préalable : utilise `vault kv put` si le path est absent, `vault kv patch` sinon — même pattern que le bloc ArgoCD GitHub OAuth

## Validation
- [x] `kubectl apply --dry-run=client -f k8s/vault/vault-bootstrap-job.yaml` — clean
- [ ] `vault-bootstrap-job` se termine sans erreur