### PR TITLE
fix(argocd): use OCI registry for Kargo Helm chart (ghcr.io/akuity/kargo-charts)

### DIFF
--- a/argocd/applications/kargo.yaml
+++ b/argocd/applications/kargo.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   sources:
-  - repoURL: https://akuity.github.io/kargo-charts
+  - repoURL: ghcr.io/akuity/kargo-charts
     chart: kargo
     targetRevision: 1.4.1
     helm:


### PR DESCRIPTION
## Summary
- Fix `ComparisonError` ArgoCD : Kargo est distribué via une OCI registry, pas un repo Helm HTTP
- Remplace `https://akuity.github.io/kargo-charts` par `ghcr.io/akuity/kargo-charts` conformément à la documentation officielle

## Validation
- [x] `kubectl apply --dry-run=client -f argocd/applications/kargo.yaml` — clean
- [ ] ArgoCD `ComparisonError` résolu