### PR TITLE
fix(helm): align kargo values.yaml with actual chart schema v1.4.1

### DIFF
--- a/helm/kargo/values.yaml
+++ b/helm/kargo/values.yaml
@@ -1,4 +1,7 @@
 api:
+  host: kargo.whispr.epitech.beer
+  adminAccount:
+    enabled: false
   ingress:
     enabled: true
     ingressClassName: nginx
@@ -8,23 +11,13 @@ api:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     tls:
-      - hosts:
-          - kargo.whispr.epitech.beer
-        secretName: kargo-tls
-    rules:
-      - host: kargo.whispr.epitech.beer
-        paths:
-          - path: /
-            pathType: Prefix
-
-oidc:
-  enabled: true
-  issuerURL: https://argocd.whispr.epitech.beer/api/dex
-  clientID: kargo
-  clientSecretSecretRef:
-    name: kargo-oidc-secret
-    key: clientSecret
-
-rbac:
-  adminRoles:
-    - github.com:whispr-messenger
+      enabled: true
+      selfSignedCert: false
+  oidc:
+    enabled: true
+    issuerURL: https://argocd.whispr.epitech.beer/api/dex
+    clientID: kargo
+    admins:
+      claims:
+        groups:
+          - whispr-messenger


### PR DESCRIPTION
## Summary
- Fix `api.ingress.tls` : doit être un objet `{enabled, selfSignedCert}` et non un tableau
- Fix `api.oidc.*` : imbriqué sous `api`, pas à la racine
- Fix RBAC : `rbac.adminRoles` n'existe pas dans ce chart — utilise `api.oidc.admins.claims.groups`
- Ajoute `api.host` requis pour la génération de l'ingress et de l'URL OIDC callback
- Désactive `adminAccount` (OIDC uniquement)

## Validation
- [x] `helm template kargo oci://ghcr.io/akuity/kargo-charts/kargo --version 1.4.1 -f helm/kargo/values.yaml` — rendu propre sans erreur