### PR TITLE
feat(argocd): manage k8s/kargo via dedicated ArgoCD Application

### DIFF
--- a/argocd/applications/kargo-config.yaml
+++ b/argocd/applications/kargo-config.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo-config
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/whispr-messenger/infrastructure
+    targetRevision: HEAD
+    path: k8s/kargo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kargo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/k8s/kargo/service-account.yaml
+++ b/k8s/kargo/service-account.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kargo-sa
+  namespace: kargo
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/k8s/kargo/vault-connection.yaml
+++ b/k8s/kargo/vault-connection.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultConnection
+metadata:
+  name: default
+  namespace: kargo
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  address: http://vault.vault.svc:8200
+  skipTLSVerify: true


### PR DESCRIPTION
## Summary

- Add a new `kargo-config` ArgoCD Application that syncs `k8s/kargo/` into the `kargo` namespace (sync-wave 5, one step before the `kargo` Helm app in sync-wave 6)
- Add the missing `ServiceAccount kargo-sa` required by the Vault Kubernetes role `kargo` and referenced by `vault-auth.yaml`
- Add the missing `VaultConnection default` required by `kargo-vault-auth`
- These resources were previously applied manually to unblock WHISPR-719 (Kargo embedded Dex); this PR brings them under GitOps management and adopts the live resources in-place

## Validation

- [x] `kubectl apply --dry-run=client` passes on all new manifests
- [ ] After merge, `kargo-config` ArgoCD Application is `Synced/Healthy` and adopts live resources without recreating them
- [ ] `kargo-dex-server` pod stays `1/1 Running` during and after the sync

Closes WHISPR-721