### PR TITLE
fix(user-service): update readiness probe path for URI versioning

### DIFF
--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -27,9 +27,12 @@ spec:
           envFrom:
             - secretRef:
                 name: user-service-env
+          env:
+            - name: DB_SYNCHRONIZE
+              value: "false"
           readinessProbe:
             httpGet:
-              path: /user/health/ready
+              path: /user/v1/health/ready
               port: 3011
             initialDelaySeconds: 20
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- Update readiness probe from /user/health/ready to /user/v1/health/ready (NestJS URI versioning)
- Override DB_SYNCHRONIZE=false to prevent accidental schema sync in prod

## Context
The new user-service image (sha-bacbe5a) enables NestJS URI versioning, which changes all route paths to include /v1/ after the global prefix. The readiness probe was returning 404, preventing the new pod from becoming Ready.