### PR TITLE
fix(k8s): add JWT_ISSUER and JWT_AUDIENCE to auth-service and user-service ConfigMaps

### DIFF
--- a/k8s/whispr/development/auth-service/configmap.yaml
+++ b/k8s/whispr/development/auth-service/configmap.yaml
@@ -28,3 +28,5 @@ data:
   MEDIA_SERVICE_GRPC_URL: "media-service.whispr-dev.svc.cluster.local:50054"
   DEMO_MODE: "true"
   OTP_BYPASS_CODE: "000000"
+  JWT_ISSUER: "https://auth.whispr.epitech.beer"
+  JWT_AUDIENCE: "whispr-api"

--- a/k8s/whispr/development/user-service/configmap.yaml
+++ b/k8s/whispr/development/user-service/configmap.yaml
@@ -30,3 +30,5 @@ data:
   SERVICE_NAME: "user-service"
   SERVICE_VERSION: "1.0.0"
   JWT_JWKS_URL: "http://auth-service.whispr-dev.svc.cluster.local:3001/auth/.well-known/jwks.json"
+  JWT_ISSUER: "https://auth.whispr.epitech.beer"
+  JWT_AUDIENCE: "whispr-api"

--- a/k8s/whispr/production/auth-service/configmap.yaml
+++ b/k8s/whispr/production/auth-service/configmap.yaml
@@ -49,3 +49,7 @@ data:
   ENABLE_CORS: "true"
   HOT_RELOAD: "false"  # Should be false in production
   DEMO_MODE: "true"
+
+  # JWT Claims
+  JWT_ISSUER: "https://auth.whispr.epitech.beer"
+  JWT_AUDIENCE: "whispr-api"

--- a/k8s/whispr/production/user-service/configmap.yaml
+++ b/k8s/whispr/production/user-service/configmap.yaml
@@ -47,3 +47,5 @@ data:
   SERVICE_NAME: "user-service"
   SERVICE_VERSION: "1.0.0"
   JWT_JWKS_URL: "http://auth-service.whispr-prod.svc.cluster.local:3001/auth/.well-known/jwks.json"
+  JWT_ISSUER: "https://auth.whispr.epitech.beer"
+  JWT_AUDIENCE: "whispr-api"


### PR DESCRIPTION
## Summary
- Add `JWT_ISSUER` and `JWT_AUDIENCE` to production and development ConfigMaps for both auth-service and user-service
- Values: `JWT_ISSUER=https://auth.whispr.epitech.beer`, `JWT_AUDIENCE=whispr-api`

## Validation
- [x] `kubectl apply --dry-run=client` passes for all 4 ConfigMaps

Closes WHISPR-836