### PR TITLE
feat(user-service): add production migration job [WHISPR-643]

### DIFF
--- a/k8s/whispr/production/user-service/deployment.yaml
+++ b/k8s/whispr/production/user-service/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     description: "User management microservice for Whispr Messenger"
     maintainer: "maia.bazerji@epitech.eu"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/k8s/whispr/production/user-service/migration-job.yaml
+++ b/k8s/whispr/production/user-service/migration-job.yaml
@@ -23,6 +23,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: user-service-sa
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -64,9 +65,11 @@ spec:
             requests:
               memory: "128Mi"
               cpu: "50m"
+              ephemeral-storage: "128Mi"
             limits:
               memory: "512Mi"
               cpu: "200m"
+              ephemeral-storage: "256Mi"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/whispr/production/user-service/migration-job.yaml
+++ b/k8s/whispr/production/user-service/migration-job.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: user-service-migration
+  namespace: whispr-prod
+  labels:
+    app: user-service
+    component: migration
+    environment: production
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: user-service
+        component: migration
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: user-service-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: Never
+      containers:
+        - name: migration
+          image: ghcr.io/whispr-messenger/user-service/user-service:sha-23cea62
+          command: ["/nodejs/bin/node"]
+          args:
+            - node_modules/typeorm/cli.js
+            - migration:run
+            - -d
+            - dist/migrations/migration.config.js
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: user-service-db-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: user-service-db-secret
+                  key: password
+            - name: DB_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+          envFrom:
+            - configMapRef:
+                name: user-service-config
+            - secretRef:
+                name: user-service-db-secret
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/whispr/production/user-service/migration-job.yaml
+++ b/k8s/whispr/production/user-service/migration-job.yaml
@@ -40,7 +40,7 @@ spec:
             - node_modules/typeorm/cli.js
             - migration:run
             - -d
-            - dist/migrations/migration.config.js
+            - dist/config/database.config.js
           env:
             - name: DB_USERNAME
               valueFrom:


### PR DESCRIPTION
## Summary
- Add a production ArgoCD migration hook Job for user-service using the same TypeORM entrypoint and DB env wiring as auth-service
- Annotate the user-service Deployment with sync-wave "2" so the migration Job runs first

## Validation
- [ ] kubectl apply --dry-run=client -f k8s/whispr/production/user-service/migration-job.yaml
- [ ] Job runs before the Deployment on every ArgoCD sync
- [ ] Deployment has sync-wave "2" annotation

Re-opened from #157 (branch was force-pushed, preventing reopen).

Closes WHISPR-643