### PR TITLE
feat(media-service): add production migration job [WHISPR-639]

### DIFF
--- a/k8s/whispr/production/media-service/deployment.yaml
+++ b/k8s/whispr/production/media-service/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     tier: backend
     environment: production
   annotations:
+    argocd.argoproj.io/sync-wave: "2"
     description: "Media management microservice for Whispr Messenger"
     maintainer: "gabriel.lopez@epitech.eu"
 spec:

--- a/k8s/whispr/production/media-service/deployment.yaml
+++ b/k8s/whispr/production/media-service/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
         - name: whispr-media-api
           # The image is automatically updated by the CD pipeline with yq
-          image: ghcr.io/whispr-messenger/media-service/media-service:latest # Placeholder, replaced by CD pipeline
+          image: ghcr.io/whispr-messenger/media-service/media-service:sha-9c36c35 # Placeholder, replaced by CD pipeline
           ports:
             - name: http
               containerPort: 3001

--- a/k8s/whispr/production/media-service/migration-job.yaml
+++ b/k8s/whispr/production/media-service/migration-job.yaml
@@ -23,6 +23,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: media-service-sa
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -64,9 +65,11 @@ spec:
             requests:
               memory: "128Mi"
               cpu: "50m"
+              ephemeral-storage: "64Mi"
             limits:
               memory: "512Mi"
               cpu: "200m"
+              ephemeral-storage: "256Mi"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/whispr/production/media-service/migration-job.yaml
+++ b/k8s/whispr/production/media-service/migration-job.yaml
@@ -34,7 +34,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migration
-          image: ghcr.io/whispr-messenger/media-service/media-service:latest
+          image: ghcr.io/whispr-messenger/media-service/media-service:sha-9c36c35
           command: ["/nodejs/bin/node"]
           args:
             - node_modules/typeorm/cli.js

--- a/k8s/whispr/production/media-service/migration-job.yaml
+++ b/k8s/whispr/production/media-service/migration-job.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: media-service-migration
+  namespace: whispr-prod
+  labels:
+    app: media-service
+    component: migration
+    environment: production
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: media-service
+        component: migration
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: media-service-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: Never
+      containers:
+        - name: migration
+          image: ghcr.io/whispr-messenger/media-service/media-service:latest
+          command: ["/nodejs/bin/node"]
+          args:
+            - node_modules/typeorm/cli.js
+            - migration:run
+            - -d
+            - dist/migrations/migration.config.js
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: media-service-db-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: media-service-db-secret
+                  key: password
+            - name: DB_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+          envFrom:
+            - configMapRef:
+                name: media-service-config
+            - secretRef:
+                name: media-service-db-secret
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary
- Add `migration-job.yaml` for media-service following the auth-service pattern
- ArgoCD Sync hook with `BeforeHookCreation` delete-policy
- sync-wave "1" on the Job, "2" on the Deployment so migrations run before the app starts
- Non-root security context, Istio sidecar disabled, backoffLimit 3

## Validation
- [ ] kubectl apply --dry-run=client succeeds for both files
- [ ] Job runs before the Deployment on every ArgoCD sync
- [ ] Deployment has sync-wave "2" annotation

Re-opened from #159 (branch was force-pushed, preventing reopen).

Closes WHISPR-639