### PR TITLE
fix(k8s): add missing MEDIA_SERVICE_URL to user-service ConfigMap

### DIFF
--- a/k8s/whispr/production/user-service/configmap.yaml
+++ b/k8s/whispr/production/user-service/configmap.yaml
@@ -37,6 +37,9 @@ data:
   # gRPC Services
   USER_SERVICE_GRPC_URL: "user-service:50052"
   MEDIA_SERVICE_GRPC_URL: "media-service:50053"
+
+  # Internal service URLs
+  MEDIA_SERVICE_URL: "http://media-service.whispr-prod.svc.cluster.local:3001"
   
   API_PREFIX: "/api"
   ENABLE_CORS: "false"


### PR DESCRIPTION
## Summary
- Add `MEDIA_SERVICE_URL` to user-service production ConfigMap
- Fixes CrashLoopBackOff caused by missing config key in `MediaClientService`

## Validation
- [x] `kubectl apply --dry-run=client` succeeds
- [ ] user-service pods start without CrashLoopBackOff
- [ ] ArgoCD sync succeeds

Closes WHISPR-987