### PR TITLE
fix(k8s): correct migration job datasource path for user-service

### DIFF
--- a/k8s/whispr/production/user-service/migration-job.yaml
+++ b/k8s/whispr/production/user-service/migration-job.yaml
@@ -40,7 +40,7 @@ spec:
             - node_modules/typeorm/cli.js
             - migration:run
             - -d
-            - dist/config/database.config.js
+            - dist/database/migration.config.js
           env:
             - name: DB_USERNAME
               valueFrom:


### PR DESCRIPTION
## Summary
- Fix incorrect datasource path in user-service migration job
- Was: `dist/config/database.config.js` (does not exist)
- Now: `dist/database/migration.config.js` (correct compiled path)
- This caused TypeORM to silently skip new migrations, leaving tables like `user_sanctions` uncreated

## Validation
- [x] `kubectl apply --dry-run=client` succeeds
- [ ] Migration job creates missing tables on next ArgoCD sync
- [ ] `SanctionExpiryService` no longer crashes

Closes WHISPR-988