### PR TITLE
fix(k8s): update user-service migration job image to current version

### DIFF
--- a/k8s/whispr/production/user-service/migration-job.yaml
+++ b/k8s/whispr/production/user-service/migration-job.yaml
@@ -34,7 +34,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migration
-          image: ghcr.io/whispr-messenger/user-service/user-service:sha-23cea62
+          image: ghcr.io/whispr-messenger/user-service/user-service:sha-57bb5a8
           command: ["/nodejs/bin/node"]
           args:
             - node_modules/typeorm/cli.js

--- a/k8s/whispr/production/user-service/migration-job.yaml
+++ b/k8s/whispr/production/user-service/migration-job.yaml
@@ -40,7 +40,7 @@ spec:
             - node_modules/typeorm/cli.js
             - migration:run
             - -d
-            - dist/config/database.config.js
+            - dist/database/migration.config.js
           env:
             - name: DB_USERNAME
               valueFrom:


### PR DESCRIPTION
## Summary
- Update migration job image from `sha-23cea62` to `sha-57bb5a8` to match the current deployment
- The old image predated the `migration.config.ts` file, so the datasource path fix from #193 could not work
- With the correct image, `dist/database/migration.config.js` exists and migrations will run properly

## Context
PR #193 fixed the datasource path but the migration job still failed because the pinned image (`sha-23cea62`) was too old to contain the file. The CD pipeline updates the Deployment image but not the migration Job image.

## Validation
- [x] `kubectl apply --dry-run=client` succeeds
- [ ] Migration job runs with the correct datasource and creates missing tables
- [ ] `SanctionExpiryService` no longer crashes

Closes WHISPR-988