### PR TITLE
fix(vault): add staging ACL health check and RBAC for redis-master-sync

### DIFF
--- a/k8s/vault/vault-rbac.yaml
+++ b/k8s/vault/vault-rbac.yaml
@@ -166,3 +166,38 @@ subjects:
   - kind: ServiceAccount
     name: vault-config
     namespace: vault
+
+---
+# Role in whispr-staging namespace to delete stale Redis credential secrets.
+# Mirrors the whispr-prod role above for staging environment parity.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vault-config-whispr-redis-health
+  namespace: whispr-staging
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - auth-service-redis-secret
+      - user-service-redis-secret
+      - media-service-redis-secret
+      - messaging-service-redis-secret
+      - scheduling-service-redis-secret
+    verbs: ["delete"]
+
+---
+# RoleBinding in whispr-staging namespace for vault-config
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-config-whispr-redis-health
+  namespace: whispr-staging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vault-config-whispr-redis-health
+subjects:
+  - kind: ServiceAccount
+    name: vault-config
+    namespace: vault

--- a/k8s/vault/vault-redis-master-sync.yaml
+++ b/k8s/vault/vault-redis-master-sync.yaml
@@ -129,14 +129,26 @@ spec:
                   else
                     for svc in auth-service user-service media-service messaging-service scheduling-service; do
                       svc_upper=$(echo "$svc" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-                      if echo "$ACL_LIST" | grep -qi "V_.*REDIS_ROLE_${svc_upper}"; then
-                        echo "ACL user for $svc: OK"
+                      SECRET_NAME="${svc}-redis-secret"
+
+                      # Production
+                      if echo "$ACL_LIST" | grep -qi "V_.*REDIS_ROLE_${svc_upper} "; then
+                        echo "ACL user for $svc (prod): OK"
                       else
-                        SECRET_NAME="${svc}-redis-secret"
-                        echo "WARNING: No ACL user found for $svc. Deleting $SECRET_NAME to force VSO rotation..."
+                        echo "WARNING: No ACL user found for $svc (prod). Deleting $SECRET_NAME to force VSO rotation..."
                         kubectl delete secret "$SECRET_NAME" -n whispr-prod --ignore-not-found=true && \
-                          echo "Deleted $SECRET_NAME — VSO will regenerate and register a fresh ACL user." || \
-                          echo "Could not delete $SECRET_NAME (RBAC or not found) — skipping."
+                          echo "Deleted $SECRET_NAME in whispr-prod — VSO will regenerate." || \
+                          echo "Could not delete $SECRET_NAME in whispr-prod — skipping."
+                      fi
+
+                      # Staging
+                      if echo "$ACL_LIST" | grep -qi "V_.*REDIS_ROLE_${svc_upper}_STAGING"; then
+                        echo "ACL user for $svc (staging): OK"
+                      else
+                        echo "WARNING: No ACL user found for $svc (staging). Deleting $SECRET_NAME to force VSO rotation..."
+                        kubectl delete secret "$SECRET_NAME" -n whispr-staging --ignore-not-found=true && \
+                          echo "Deleted $SECRET_NAME in whispr-staging — VSO will regenerate." || \
+                          echo "Could not delete $SECRET_NAME in whispr-staging — skipping."
                       fi
                     done
                   fi


### PR DESCRIPTION
## Summary\n- Add staging service ACL health checks in `vault-redis-master-sync` CronJob Step 6 — after a Redis restart, staging credentials are now rotated alongside production ones\n- Add `Role` and `RoleBinding` in `whispr-staging` namespace to allow `vault-config` SA to delete stale Redis credential secrets for VSO rotation\n\n## Validation\n- [x] `kubectl apply --dry-run=client` passes for both modified manifests\n- [ ] ArgoCD sync succeeds\n\nCloses WHISPR-1031