### PR TITLE
[WHISPR-198] feat(observability): register Grafana in ArgoCD preprod + prod

### DIFF
--- a/argocd-preprod-citadel/applications/grafana.yaml
+++ b/argocd-preprod-citadel/applications/grafana.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: preprod-grafana
+  namespace: argocd-preprod
+  annotations:
+    argocd.argoproj.io/sync-wave: "8"
+spec:
+  project: default
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: observability
+
+  sources:
+    - repoURL: https://github.com/whispr-messenger/infrastructure.git
+      targetRevision: deploy/preprod
+      path: helm/grafana
+      helm:
+        valueFiles:
+          - values.yaml
+
+    - repoURL: https://github.com/whispr-messenger/infrastructure.git
+      targetRevision: deploy/preprod
+      path: k8s/grafana
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd-prod-citadel/applications/grafana.yaml
+++ b/argocd-prod-citadel/applications/grafana.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: citadel-grafana
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "8"
+spec:
+  project: default
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: observability
+
+  sources:
+    - repoURL: https://github.com/whispr-messenger/infrastructure.git
+      targetRevision: main
+      path: helm/grafana
+      helm:
+        valueFiles:
+          - values.yaml
+
+    - repoURL: https://github.com/whispr-messenger/infrastructure.git
+      targetRevision: main
+      path: k8s/grafana
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m


### PR DESCRIPTION
## Ticket
[WHISPR-198](https://whisprrr.atlassian.net/browse/WHISPR-198) — [Infrastructure] Déployer Grafana avec Helm et ArgoCD (mode dev + prod)

## Changes
Declares two ArgoCD Applications that register Grafana in the preprod and prod ArgoCD app-of-apps:

- `argocd-preprod-citadel/applications/grafana.yaml` → `preprod-grafana`, targets `deploy/preprod`
- `argocd-prod-citadel/applications/grafana.yaml` → `citadel-grafana`, targets `main`

Both apps are multi-source:
1. `helm/grafana/` — wrapper chart (Grafana 8.* via helm dep)
2. `k8s/grafana/` — Vault integration + ingress

Destination namespace `observability` (auto-created), sync-wave `8`.

## Rationale
Ticket reports "Grafana not deployed". Code was ready in `helm/grafana/` + `k8s/grafana/` but no Application manifest existed in the per-env app-of-apps folders (`argocd-{preprod,prod}-citadel/applications/`), so neither ArgoCD instance was aware of it. This PR registers the Application on both sides.

## Known caveats (follow-up tickets recommended)
Once the app starts syncing, the following existing issues in `k8s/grafana/` will surface and need separate PRs:

1. **Vault mount mismatch** — `k8s/grafana/vault-{admin,oauth}-secret.yaml` uses `mount: kv`, but the home-lab Vault only has `secret/` (kv-v2) mounted. Needs `mount: secret`.
2. **Vault role missing** — `vault-auth.yaml` references role `vault-admin` with default SA; no matching k8s auth role exists. Needs a dedicated `grafana` role or reuse of an existing service role.
3. **Ingress host hardcoded** — `k8s/grafana/ingress.yaml` uses `grafana.whispr.epitech.beer` (legacy domain). Preprod needs `grafana-preprod.roadmvn.com`, prod needs `grafana.roadmvn.com`. Fix via kustomize overlay or split into per-env folders.
4. **GitHub OAuth secret** — `helm/grafana/values.yaml` references `grafana-oauth-secret`; the Vault path is missing. Either disable OAuth in preprod via values override, or populate Vault.

None of these block the Application *declaration*, which is the core scope of WHISPR-198. They block the *sync to Healthy*, which I've left for follow-up tickets (happy to open them after this merges if you want).

## Test plan
- [x] YAML schema validated (pyyaml parse + structure check on both files)
- [ ] Preprod ArgoCD picks up new app after merge (visible in `preprod-argocd.roadmvn.com` UI)
- [ ] If sync fails with above caveats, open follow-up tickets for each

## Files
- `argocd-preprod-citadel/applications/grafana.yaml` (new, 40 lines)
- `argocd-prod-citadel/applications/grafana.yaml` (new, 40 lines)

[WHISPR-198]: https://whisprrr.atlassian.net/browse/WHISPR-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ