### PR TITLE
[WHISPR-219] feat(argocd): split apps into whispr-infra and whispr-app projects

### DIFF
--- a/argocd-preprod-citadel/applications/_project-whispr-app.yaml
+++ b/argocd-preprod-citadel/applications/_project-whispr-app.yaml
@@ -1,0 +1,34 @@
+---
+# AppProject: whispr-app
+# Contains the Whispr application workloads (microservices + web client).
+# Scoped to the whispr-preprod namespace; cluster-scoped resources are
+# restricted to what ingress/CRDs require.
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: whispr-app
+  namespace: argocd-preprod
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Whispr application workloads on preprod (microservices, web, realtime).
+  sourceRepos:
+    - https://github.com/whispr-messenger/infrastructure.git
+    - https://helm.livekit.io
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: whispr-preprod
+  clusterResourceWhitelist:
+    - group: ''
+      kind: Namespace
+    - group: 'networking.k8s.io'
+      kind: Ingress
+    - group: 'cert-manager.io'
+      kind: '*'
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  orphanedResources:
+    warn: true

--- a/argocd-preprod-citadel/applications/_project-whispr-infra.yaml
+++ b/argocd-preprod-citadel/applications/_project-whispr-infra.yaml
@@ -1,0 +1,31 @@
+---
+# AppProject: whispr-infra
+# Contains cluster-level / shared infrastructure (namespaces, Vault bootstrap,
+# secrets, observability hooks, network plumbing). Applications in this
+# project may create cluster-scoped resources and target any namespace.
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: whispr-infra
+  namespace: argocd-preprod
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Shared infrastructure for the preprod cluster (namespaces, secrets, observability).
+  sourceRepos:
+    - https://github.com/whispr-messenger/infrastructure.git
+    - https://grafana.github.io/helm-charts
+    - https://prometheus-community.github.io/helm-charts
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  orphanedResources:
+    warn: true

--- a/argocd-preprod-citadel/applications/auth-service.yaml
+++ b/argocd-preprod-citadel/applications/auth-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/calls-service.yaml
+++ b/argocd-preprod-citadel/applications/calls-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/infra.yaml
+++ b/argocd-preprod-citadel/applications/infra.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  project: default
+  project: whispr-infra
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/livekit.yaml
+++ b/argocd-preprod-citadel/applications/livekit.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   sources:
     - repoURL: https://helm.livekit.io
       chart: livekit-server
@@ -43,7 +43,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "6"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/media-service.yaml
+++ b/argocd-preprod-citadel/applications/media-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/messaging-service.yaml
+++ b/argocd-preprod-citadel/applications/messaging-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/mobile-web.yaml
+++ b/argocd-preprod-citadel/applications/mobile-web.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/moderation-service.yaml
+++ b/argocd-preprod-citadel/applications/moderation-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/notification-service.yaml
+++ b/argocd-preprod-citadel/applications/notification-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/scheduling-service.yaml
+++ b/argocd-preprod-citadel/applications/scheduling-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/applications/user-service.yaml
+++ b/argocd-preprod-citadel/applications/user-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-preprod-citadel/root.yaml
+++ b/argocd-preprod-citadel/root.yaml
@@ -5,7 +5,7 @@ metadata:
   name: whispr-preprod
   namespace: argocd-preprod
 spec:
-  project: default
+  project: whispr-infra
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: deploy/preprod

--- a/argocd-prod-citadel/applications/_project-whispr-app.yaml
+++ b/argocd-prod-citadel/applications/_project-whispr-app.yaml
@@ -1,0 +1,34 @@
+---
+# AppProject: whispr-app
+# Contains the Whispr application workloads (microservices + web client).
+# Scoped to the whispr-prod namespace; cluster-scoped resources are
+# restricted to what ingress/CRDs require.
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: whispr-app
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Whispr application workloads on prod (microservices, web, realtime).
+  sourceRepos:
+    - https://github.com/whispr-messenger/infrastructure.git
+    - https://helm.livekit.io
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: whispr-prod
+  clusterResourceWhitelist:
+    - group: ''
+      kind: Namespace
+    - group: 'networking.k8s.io'
+      kind: Ingress
+    - group: 'cert-manager.io'
+      kind: '*'
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  orphanedResources:
+    warn: true

--- a/argocd-prod-citadel/applications/_project-whispr-infra.yaml
+++ b/argocd-prod-citadel/applications/_project-whispr-infra.yaml
@@ -1,0 +1,31 @@
+---
+# AppProject: whispr-infra
+# Contains cluster-level / shared infrastructure (namespaces, Vault bootstrap,
+# secrets, observability hooks, network plumbing). Applications in this
+# project may create cluster-scoped resources and target any namespace.
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: whispr-infra
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Shared infrastructure for the prod cluster (namespaces, secrets, observability).
+  sourceRepos:
+    - https://github.com/whispr-messenger/infrastructure.git
+    - https://grafana.github.io/helm-charts
+    - https://prometheus-community.github.io/helm-charts
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  orphanedResources:
+    warn: true

--- a/argocd-prod-citadel/applications/auth-service.yaml
+++ b/argocd-prod-citadel/applications/auth-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/infra.yaml
+++ b/argocd-prod-citadel/applications/infra.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  project: default
+  project: whispr-infra
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/media-service.yaml
+++ b/argocd-prod-citadel/applications/media-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/messaging-service.yaml
+++ b/argocd-prod-citadel/applications/messaging-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/mobile-web.yaml
+++ b/argocd-prod-citadel/applications/mobile-web.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/moderation-service.yaml
+++ b/argocd-prod-citadel/applications/moderation-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/notification-service.yaml
+++ b/argocd-prod-citadel/applications/notification-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/scheduling-service.yaml
+++ b/argocd-prod-citadel/applications/scheduling-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/applications/user-service.yaml
+++ b/argocd-prod-citadel/applications/user-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  project: default
+  project: whispr-app
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main

--- a/argocd-prod-citadel/root.yaml
+++ b/argocd-prod-citadel/root.yaml
@@ -5,7 +5,7 @@ metadata:
   name: whispr-citadel
   namespace: argocd
 spec:
-  project: default
+  project: whispr-infra
   source:
     repoURL: https://github.com/whispr-messenger/infrastructure.git
     targetRevision: main


### PR DESCRIPTION
## Summary
Replace the implicit `default` AppProject with two scoped projects per cluster (prod and preprod):

- **`whispr-infra`** — cluster-level / shared infrastructure (namespaces, Vault bootstrap, observability, network plumbing). Wide `clusterResourceWhitelist` because it must create namespaces, CRDs, etc.
- **`whispr-app`** — application workloads (auth, calls, media, messaging, moderation, notification, scheduling, user, mobile-web, livekit). Destination scoped to `whispr-{env}` namespace, `clusterResourceWhitelist` restricted to `Namespace` / `Ingress` / `cert-manager.io/*`.

Both projects set `orphanedResources.warn: true` and scope `sourceRepos` to the infra repo plus the external helm repos actually used (`grafana.github.io/helm-charts` and `prometheus-community.github.io/helm-charts` for infra; `helm.livekit.io` for app).

## Files
- `argocd-preprod-citadel/applications/_project-whispr-{infra,app}.yaml` (new)
- `argocd-prod-citadel/applications/_project-whispr-{infra,app}.yaml` (new)
- All existing `Application` manifests migrated from `project: default` to the right project
- Both `root.yaml` files moved to `whispr-infra`

## Validation
- [x] YAML parse OK for all 26 changed files
- [x] Every referenced `sourceRepos` entry is covered (verified via grep on `repoURL:` across both applications/ directories)
- [ ] ArgoCD sync succeeds (will verify after merge + `root` refresh)

## Context
Before this change, every Application ran under the implicit `default` AppProject, which gave them unconstrained access. Splitting lets us tighten `whispr-app` to its namespace and keep infra privileges to a single project.

Closes WHISPR-219