### PR TITLE
feat(scheduling-service): add Kubernetes migration Job

### DIFF
--- a/k8s/whispr/production/scheduling-service/migration-job.yaml
+++ b/k8s/whispr/production/scheduling-service/migration-job.yaml
@@ -65,9 +65,11 @@ spec:
             requests:
               memory: "128Mi"
               cpu: "50m"
+              ephemeral-storage: "100Mi"
             limits:
               memory: "512Mi"
               cpu: "200m"
+              ephemeral-storage: "500Mi"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/whispr/production/scheduling-service/migration-job.yaml
+++ b/k8s/whispr/production/scheduling-service/migration-job.yaml
@@ -1,0 +1,84 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: scheduling-service-migration
+  namespace: whispr-prod
+  labels:
+    app: scheduling-service
+    component: migration
+    environment: production
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: scheduling-service
+        component: migration
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: scheduling-service-sa
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: Never
+      containers:
+        - name: migration
+          image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-78e7bc4
+          command: ["/nodejs/bin/node"]
+          args:
+            - node_modules/typeorm/cli.js
+            - migration:run
+            - -d
+            - dist/modules/app/migrations/migration.config.js
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: scheduling-service-db-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: scheduling-service-db-secret
+                  key: password
+            - name: DB_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+          envFrom:
+            - configMapRef:
+                name: scheduling-service-config
+            - secretRef:
+                name: scheduling-service-db-secret
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary
- Adds `k8s/whispr/production/scheduling-service/migration-job.yaml`
- ArgoCD PreSync hook Job (sync-wave 1, `hook-delete-policy: BeforeHookCreation`)
- Runs TypeORM migrations via `node_modules/typeorm/cli.js migration:run` against `dist/modules/app/migrations/migration.config.js`
- Mirrors the pattern already in place for auth-service and user-service

## Validation
- [x] `kubectl create --dry-run=client` clean
- [ ] ArgoCD sync on preprod picks up the Job when merged to `deploy/preprod`

Closes WHISPR-642