### PR TITLE
feat(notification-service): add Kubernetes migration Job

### DIFF
--- a/k8s/whispr/production/notification-service/migration-job.yaml
+++ b/k8s/whispr/production/notification-service/migration-job.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: notification-service-migration
+  namespace: whispr-prod
+  labels:
+    app: notification-service
+    component: migration
+    environment: production
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: notification-service
+        component: migration
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: notification-service-sa
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: Never
+      containers:
+        - name: migration
+          image: ghcr.io/whispr-messenger/notification-service:sha-7bbe53d
+          command: ["/app/bin/whispr_notification"]
+          args:
+            - eval
+            - WhisprNotifications.Release.migrate()
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-db-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-db-secret
+                  key: password
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            # Phoenix runtime.exs requires a 64-byte SECRET_KEY_BASE even for
+            # migrations. The endpoint is never started by `eval`, so this
+            # placeholder is only consumed by the config validator.
+            - name: SECRET_KEY_BASE
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          envFrom:
+            - configMapRef:
+                name: notification-service-config
+            - secretRef:
+                name: notification-service-db-secret
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+              ephemeral-storage: "100Mi"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+              ephemeral-storage: "500Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL


### PR DESCRIPTION
## Summary
- Adds `k8s/whispr/production/notification-service/migration-job.yaml`
- ArgoCD PreSync hook Job (sync-wave 1, `hook-delete-policy: BeforeHookCreation`)
- Runs the Elixir release task `WhisprNotifications.Release.migrate/0` — same command the Docker entrypoint executes on container start — so schema changes are applied once per ArgoCD sync rather than per pod start
- Uses `whispr` user (UID 1000) to match the service's runtime image

## Validation
- [x] `kubectl create --dry-run=client` clean
- [ ] ArgoCD sync on preprod picks up the Job when merged to `deploy/preprod`

Closes WHISPR-641