### PR TITLE
feat(k8s): add shared internal-api-token secret for preprod user/messaging services

### DIFF
--- a/k8s/whispr/preprod/infra/shared-internal-api-token.yaml
+++ b/k8s/whispr/preprod/infra/shared-internal-api-token.yaml
@@ -1,0 +1,27 @@
+---
+# Shared service-to-service auth token for the user-service ↔ messaging-service
+# internal API (WHISPR-1229: GET /internal/v1/contacts/check, header
+# x-internal-token, env INTERNAL_API_TOKEN). Both Deployments mount the same
+# Secret/key — any drift between sender and receiver yields a 401.
+#
+# The token is bootstrapped out-of-band (kubectl) and ArgoCD MUST NOT overwrite
+# the data field. We declare only the Secret shell here (metadata + type, no
+# stringData) and rely on ServerSideApply so the kubectl-applied data is owned
+# by the bootstrap (or a future Vault projection), not by Git.
+#
+# Bootstrap command (rerun to rotate; rolling-restart both Deployments after):
+#
+#   kubectl -n whispr-preprod create secret generic shared-internal-api-token \
+#     --from-literal=INTERNAL_API_TOKEN="$(openssl rand -hex 32)" \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# The data key MUST be "INTERNAL_API_TOKEN" — both Deployments reference it via
+# secretKeyRef.key under that exact name.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shared-internal-api-token
+  namespace: whispr-preprod
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+type: Opaque

--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -37,6 +37,11 @@ spec:
               value: redis-master.redis.svc.cluster.local
             - name: HTTP_PORT
               value: "4010"
+            - name: INTERNAL_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: shared-internal-api-token
+                  key: INTERNAL_API_TOKEN
           resources:
             requests:
               memory: 256Mi

--- a/k8s/whispr/preprod/user-service/deployment.yaml
+++ b/k8s/whispr/preprod/user-service/deployment.yaml
@@ -37,6 +37,11 @@ spec:
               value: redis-master.redis.svc.cluster.local
             - name: SEED_ADMIN_USER_IDS
               value: "fab8817a-27a0-4537-89c1-be05f783150b,3378ee73-ce43-4145-b689-ba982d97721e"
+            - name: INTERNAL_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: shared-internal-api-token
+                  key: INTERNAL_API_TOKEN
           resources:
             requests:
               memory: 128Mi


### PR DESCRIPTION
## Summary

- Add a `shared-internal-api-token` Secret shell in `whispr-preprod` (metadata + type only, no `stringData`) with `argocd.argoproj.io/sync-options: ServerSideApply=true` so ArgoCD does not overwrite the kubectl-applied token. Same pattern as `notification-service-fcm` (commit 5fd0de2).
- Wire `INTERNAL_API_TOKEN` env var into the preprod `user-service` and `messaging-service` Deployments via `secretKeyRef` on the same Secret/key. user-service validates inbound `x-internal-token`, messaging-service signs outbound calls — WHISPR-1229.
- The actual token is bootstrapped out-of-band (kubectl), never committed.

## Bootstrap (run once before ArgoCD syncs the Deployments)

```sh
kubectl -n whispr-preprod create secret generic shared-internal-api-token \
  --from-literal=INTERNAL_API_TOKEN="$(openssl rand -hex 32)" \
  --dry-run=client -o yaml | kubectl apply -f -
```

Rotation = rerun the same command, then rolling-restart both Deployments.

## Validation

- [x] `kubectl apply --dry-run=client` clean on the Secret and both Deployments
- [ ] Bootstrap command run against preprod cluster
- [ ] ArgoCD sync succeeds (Secret stays unmanaged on the data field, env var injected)
- [ ] user-service preprod passes its startupProbe (no more `Internal API not configured`)

## Follow-ups (out of scope here)

- Reproduce in prod with a different token value.
- Document the rotation procedure.

Closes WHISPR-1232
Related WHISPR-1229