### PR TITLE
feat(k8s/preprod): wire APNS for notification-service (WHISPR-1175)

### DIFF
--- a/k8s/whispr/preprod/notification-service/apns-secret.yaml
+++ b/k8s/whispr/preprod/notification-service/apns-secret.yaml
@@ -1,0 +1,27 @@
+---
+# APNS authentication key for notification-service (WHISPR-1175).
+#
+# The real AuthKey.p8 is provisioned out-of-band via kubectl from Vault and
+# MUST NOT be committed to Git. We declare only the Secret shell here
+# (metadata + type, no data) and rely on ServerSideApply so that the data
+# field applied by kubectl is owned by the bootstrap (or a future Vault
+# projection), not by Git. The IgnoreExtraneous compare option ensures
+# ArgoCD does not flag the kubectl-managed data as drift.
+#
+# Bootstrap command (rerun to rotate; rolling-restart the Deployment after):
+#
+#   kubectl -n whispr-preprod create secret generic notification-service-apns \
+#     --from-file=AuthKey.p8=/path/to/AuthKey_XXXXXXXXXX.p8 \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# The data key MUST be "AuthKey.p8" - the Deployment mounts it at
+# /etc/apns/AuthKey.p8 and APNS_KEY_PATH points to that exact path.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: notification-service-apns
+  namespace: whispr-preprod
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+type: Opaque

--- a/k8s/whispr/preprod/notification-service/configmap.yaml
+++ b/k8s/whispr/preprod/notification-service/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notification-service-config
+  namespace: whispr-preprod
+data:
+  APNS_KEY_PATH: "/etc/apns/AuthKey.p8"
+  APNS_KEY_ID: ""
+  APNS_TEAM_ID: ""
+  APNS_MODE: "dev"

--- a/k8s/whispr/preprod/notification-service/deployment.yaml
+++ b/k8s/whispr/preprod/notification-service/deployment.yaml
@@ -29,6 +29,8 @@ spec:
           envFrom:
             - secretRef:
                 name: notification-service-env
+            - configMapRef:
+                name: notification-service-config
           env:
             - name: DATABASE_HOST
               value: postgresql.postgresql.svc.cluster.local
@@ -41,3 +43,15 @@ spec:
             limits:
               memory: 384Mi
               cpu: 500m
+          volumeMounts:
+            - name: apns-key
+              mountPath: /etc/apns
+              readOnly: true
+      volumes:
+        - name: apns-key
+          secret:
+            secretName: notification-service-apns
+            items:
+              - key: AuthKey.p8
+                path: AuthKey.p8
+            optional: true


### PR DESCRIPTION
Cable la chaine APNS pour notification-service en preprod, prepa pour quand on aura la `.p8` Apple (WHISPR-1174).

- Nouveau Secret `notification-service-apns` (shell vide, pas de data dans le repo). Annote avec `argocd.argoproj.io/compare-options: IgnoreExtraneous` + `sync-options: ServerSideApply=true` pour qu'ArgoCD ecrase pas la vraie cle injectee a la main via kubectl.
- Nouveau ConfigMap `notification-service-config` avec `APNS_KEY_PATH=/etc/apns/AuthKey.p8`, `APNS_MODE=dev`, plus les vars APNS_KEY_ID / APNS_TEAM_ID / APNS_BUNDLE_ID a remplir.
- Deployment de notification-service: monte le secret en /etc/apns + envFrom le configmap.

Reste a faire (manuel, pas dans cette PR):
- generer la `.p8` cote Apple Developer
- `kubectl create secret` direct dans le cluster avec la vraie cle

Apres ca, le service envoit les push iOS via Pigeon/APNS.