### PR TITLE
fix(security): durcissement sonar - automount, storage limits, gha injection

### DIFF
--- a/.github/workflows/cd-vault-config-job.yml
+++ b/.github/workflows/cd-vault-config-job.yml
@@ -48,28 +48,33 @@ jobs:
 
       - name: Validate and determine commit SHA
         id: validate_commit
+        env:
+          INPUT_COMMIT_SHA: ${{ inputs.commit_sha }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GITHUB_SHA_FALLBACK: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ -n "${{ inputs.commit_sha }}" ]; then
-              COMMIT_SHA="${{ inputs.commit_sha }}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ -n "$INPUT_COMMIT_SHA" ]; then
+              COMMIT_SHA="$INPUT_COMMIT_SHA"
               echo "Validating manually provided commit SHA: $COMMIT_SHA"
               if ! echo "$COMMIT_SHA" | grep -qE '^[a-fA-F0-9]{7,40}$'; then
-                echo "❌ Error: Invalid commit SHA format."
+                echo "Error: Invalid commit SHA format."
                 exit 1
               fi
               # Pad short SHA to full length for consistency (no git rev-parse:
               # checkout is shallow so historical commits may not be present)
-              echo "✅ Commit SHA format valid: $COMMIT_SHA"
+              echo "Commit SHA format valid: $COMMIT_SHA"
             else
-              COMMIT_SHA="${{ github.sha }}"
+              COMMIT_SHA="$GITHUB_SHA_FALLBACK"
             fi
           else
-            COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+            COMMIT_SHA="$WORKFLOW_RUN_HEAD_SHA"
             if [ -z "$COMMIT_SHA" ]; then
-              COMMIT_SHA="${{ github.sha }}"
+              COMMIT_SHA="$GITHUB_SHA_FALLBACK"
             fi
           fi
-          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Update image tag in deployment
         run: |

--- a/k8s/vault/vault-bootstrap-job.yaml
+++ b/k8s/vault/vault-bootstrap-job.yaml
@@ -16,6 +16,14 @@ spec:
       containers:
         - name: vault-config
           image: ghcr.io/whispr-messenger/vault-config-job:sha-4cea5de
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 50m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+              ephemeral-storage: 512Mi
           env:
             - name: VAULT_ADDR
               value: http://vault.vault.svc:8200

--- a/k8s/whispr/development/auth-service/deployment.yaml
+++ b/k8s/whispr/development/auth-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: auth-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: whispr-auth-api
           image: auth-service:latest
@@ -94,6 +95,7 @@ spec:
             limits:
               memory: "1Gi"
               cpu: "1000m"
+              ephemeral-storage: 1Gi
           livenessProbe:
             httpGet:
               path: /auth/v1/health/live

--- a/k8s/whispr/development/media-service/deployment.yaml
+++ b/k8s/whispr/development/media-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: media-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: whispr-media-api
           image: media-service:latest
@@ -83,6 +84,7 @@ spec:
             limits:
               memory: "1Gi"
               cpu: "1000m"
+              ephemeral-storage: 1Gi
           livenessProbe:
             httpGet:
               path: /media/v1/health/live

--- a/k8s/whispr/development/messaging-service/deployment.yaml
+++ b/k8s/whispr/development/messaging-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: messaging-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: whispr-messaging-api
           image: messaging-service:dev

--- a/k8s/whispr/development/notification-service/deployment.yaml
+++ b/k8s/whispr/development/notification-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: notification-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: whispr-notification-api
           image: notification-service:dev

--- a/k8s/whispr/development/postgres/deployment.yaml
+++ b/k8s/whispr/development/postgres/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: postgres
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: postgres
           image: postgres:15-alpine
@@ -54,6 +55,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
+              ephemeral-storage: 1Gi
       volumes:
         - name: postgres-data
           emptyDir: {}

--- a/k8s/whispr/development/redis/deployment.yaml
+++ b/k8s/whispr/development/redis/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: redis
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: redis
           image: redis:7-alpine
@@ -42,6 +43,7 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "200m"
+              ephemeral-storage: 1Gi
           volumeMounts:
             - name: redis-data
               mountPath: /data

--- a/k8s/whispr/development/scheduling-service/deployment.yaml
+++ b/k8s/whispr/development/scheduling-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: scheduling-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: whispr-scheduling-api
           image: scheduling-service:latest
@@ -88,6 +89,7 @@ spec:
             limits:
               memory: "1Gi"
               cpu: "1000m"
+              ephemeral-storage: 1Gi
           livenessProbe:
             httpGet:
               path: /health/live

--- a/k8s/whispr/development/user-service/deployment.yaml
+++ b/k8s/whispr/development/user-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: user-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: whispr-user-api
           image: user-service:latest
@@ -73,6 +74,7 @@ spec:
             limits:
               memory: "1Gi"
               cpu: "1000m"
+              ephemeral-storage: 1Gi
           livenessProbe:
             httpGet:
               path: /user/v1/health/live

--- a/k8s/whispr/preprod/auth-service/deployment.yaml
+++ b/k8s/whispr/preprod/auth-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: auth-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: auth-service
           image: ghcr.io/whispr-messenger/auth-service/auth-service:sha-19850e7

--- a/k8s/whispr/preprod/media-service/deployment.yaml
+++ b/k8s/whispr/preprod/media-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: media-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: media-service
           image: ghcr.io/whispr-messenger/media-service/media-service:sha-c96a2d5

--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: messaging-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: messaging-service
           image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-7e5e72d

--- a/k8s/whispr/preprod/mobile-web/deployment.yaml
+++ b/k8s/whispr/preprod/mobile-web/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: mobile-web
     spec:
+      automountServiceAccountToken: false
       containers:
         - image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-7bde217
           imagePullPolicy: Always

--- a/k8s/whispr/preprod/moderation-service/deployment.yaml
+++ b/k8s/whispr/preprod/moderation-service/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: moderation-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: moderation-service
           image: ghcr.io/whispr-messenger/moderation-service:preprod

--- a/k8s/whispr/preprod/notification-service/deployment.yaml
+++ b/k8s/whispr/preprod/notification-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: notification-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: notification-service
           image: ghcr.io/whispr-messenger/notification-service:sha-63c3b63

--- a/k8s/whispr/preprod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/preprod/scheduling-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: scheduling-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: scheduling-service
           image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-cbb7ed8

--- a/k8s/whispr/preprod/user-service/deployment.yaml
+++ b/k8s/whispr/preprod/user-service/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: user-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: user-service
           image: ghcr.io/whispr-messenger/user-service/user-service:sha-86b51e7

--- a/k8s/whispr/prod/auth-service/deployment.yaml
+++ b/k8s/whispr/prod/auth-service/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: auth-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: auth-service
           image: ghcr.io/whispr-messenger/auth-service/auth-service:sha-b1ff3fc

--- a/k8s/whispr/prod/infra/minio.yaml
+++ b/k8s/whispr/prod/infra/minio.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: minio
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: minio
           image: minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
@@ -45,6 +46,7 @@ spec:
             limits:
               memory: 1Gi
               cpu: 500m
+              ephemeral-storage: 1Gi
           readinessProbe:
             httpGet:
               path: /minio/health/ready

--- a/k8s/whispr/prod/infra/postgres.yaml
+++ b/k8s/whispr/prod/infra/postgres.yaml
@@ -32,6 +32,7 @@ spec:
       labels:
         app: postgresql
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: postgresql
           image: postgres:15-alpine
@@ -57,6 +58,7 @@ spec:
             limits:
               memory: 1Gi
               cpu: 500m
+              ephemeral-storage: 1Gi
           readinessProbe:
             exec:
               command:

--- a/k8s/whispr/prod/infra/redis.yaml
+++ b/k8s/whispr/prod/infra/redis.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: redis
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: redis
           image: redis:7-alpine
@@ -38,6 +39,7 @@ spec:
             limits:
               memory: 512Mi
               cpu: 250m
+              ephemeral-storage: 1Gi
           readinessProbe:
             exec:
               command:

--- a/k8s/whispr/prod/media-service/deployment.yaml
+++ b/k8s/whispr/prod/media-service/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: media-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: media-service
           image: ghcr.io/whispr-messenger/media-service/media-service:sha-c96a2d5

--- a/k8s/whispr/prod/messaging-service/deployment.yaml
+++ b/k8s/whispr/prod/messaging-service/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: messaging-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: messaging-service
           image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-3ce6b5f

--- a/k8s/whispr/prod/mobile-web/deployment.yaml
+++ b/k8s/whispr/prod/mobile-web/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: mobile-web
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: mobile-web
           image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-4bd3396

--- a/k8s/whispr/prod/moderation-service/deployment.yaml
+++ b/k8s/whispr/prod/moderation-service/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: moderation-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: moderation-service
           image: ghcr.io/whispr-messenger/moderation-service:sha-7e4116b

--- a/k8s/whispr/prod/notification-service/deployment.yaml
+++ b/k8s/whispr/prod/notification-service/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: notification-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: notification-service
           image: ghcr.io/whispr-messenger/notification-service:sha-ff3c8a0

--- a/k8s/whispr/prod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/prod/scheduling-service/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: scheduling-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: scheduling-service
           image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-0a33c0b

--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: user-service
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: user-service
           image: ghcr.io/whispr-messenger/user-service/user-service:sha-57bb5a8

--- a/k8s/whispr/production/auth-service/deployment.yaml
+++ b/k8s/whispr/production/auth-service/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      automountServiceAccountToken: false
       containers:
         - name: whispr-auth-api
           # The image is automatically updated by the CD pipeline with yq
@@ -97,6 +98,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "200m"
+              ephemeral-storage: 1Gi
           # Security context for the container
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8s/whispr/production/auth-service/migration-job.yaml
+++ b/k8s/whispr/production/auth-service/migration-job.yaml
@@ -31,6 +31,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: Never
+      automountServiceAccountToken: false
       containers:
         - name: migration
           image: ghcr.io/whispr-messenger/auth-service/auth-service:sha-822b3cb
@@ -67,6 +68,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "200m"
+              ephemeral-storage: 1Gi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/whispr/production/media-service/deployment.yaml
+++ b/k8s/whispr/production/media-service/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "200m"
-              ephemeral-storage: 1Gi
+              ephemeral-storage: 2Gi
           # Security context for the container
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8s/whispr/production/media-service/deployment.yaml
+++ b/k8s/whispr/production/media-service/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      automountServiceAccountToken: false
       containers:
         - name: whispr-media-api
           # The image is automatically updated by the CD pipeline with yq
@@ -98,6 +99,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "200m"
+              ephemeral-storage: 1Gi
           # Security context for the container
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8s/whispr/production/messaging-service/deployment.yaml
+++ b/k8s/whispr/production/messaging-service/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+      automountServiceAccountToken: false
       containers:
         - name: messaging-service
           image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-3ce6b5f
@@ -89,6 +90,7 @@ spec:
             limits:
               cpu: "200m"
               memory: "512Mi"
+              ephemeral-storage: 1Gi
           livenessProbe:
             httpGet:
               path: /live

--- a/k8s/whispr/production/notification-service/deployment.yaml
+++ b/k8s/whispr/production/notification-service/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: notification-service
     spec:
       serviceAccountName: notification-service-sa
+      automountServiceAccountToken: false
       containers:
         - name: notification-service
           image: ghcr.io/whispr-messenger/notification-service:sha-ff3c8a0

--- a/k8s/whispr/production/scheduling-service/deployment.yaml
+++ b/k8s/whispr/production/scheduling-service/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+      automountServiceAccountToken: false
       containers:
         - name: scheduling-service
           image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-0a33c0b

--- a/k8s/whispr/production/user-service/deployment.yaml
+++ b/k8s/whispr/production/user-service/deployment.yaml
@@ -31,6 +31,7 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      automountServiceAccountToken: false
       containers:
         - name: whispr-user-api
           # the image is automatically updated by the CD pipeline with yq
@@ -87,6 +88,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "200m"
+              ephemeral-storage: 1Gi
           # Security context for the container
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Contexte

Le repo infrastructure est en Security E (62 vulns) sur SonarCloud. Cette PR adresse 51 vulnérabilités sur 62 et laisse les 11 restantes hors scope (justification ci-dessous).

## Changements

- **34x kubernetes:S6865** - ajout de `automountServiceAccountToken: false` sur tous les pod templates (preprod, prod, development, production overlays).
- **14x kubernetes:S6870** - ajout de `ephemeral-storage: 1Gi` dans `resources.limits` sur les containers concernés.
- **1x kubernetes:S6864** - ajout d'un bloc `resources` complet sur le job `vault-bootstrap-job`.
- **2x githubactions:S7630** - passage de `inputs.commit_sha`, `github.event_name`, etc. via `env:` au lieu d'interpolation directe dans `run:`.

## Hors scope (justifications)

- **7x kubernetes:S6867 wildcards RBAC** sur `k8s/rbac/platform-engineers-rbac.yaml` - cluster GKE collègues (epitech.beer), risque trop élevé pour modifier les permissions IAM existantes sans validation.
- **2x secrets:S6706 private keys JWT** dans `preprod/infra/jwt-keys.yaml` et `prod/infra/jwt-keys.yaml` - manifests réels, rotation hors scope sécu Sonar.
- **1x secrets:S8215 bcrypt argocd** dans `helm/argocd/values.yaml` - admin password legitimement encrypté.
- **1x kubernetes:S6418 hardcoded secret** notification-service/deployment.yaml prod legacy - à analyser séparément.
- **30 hotspots TO_REVIEW** non touchés (RBAC pods/exec, terraform GKE public, Dockerfile root, HTTP interne vault) - reviewables en bulk SAFE depuis l'UI Sonar mais nécessitent validation humaine.

## Validation

- `python3 -c "import yaml; ..."` sur tous les manifests touchés - 167 fichiers OK, 0 erreur.
- Diff manuel : aucune route supprimée, aucune image bumpée, aucun secret réel modifié.

## Impact ArgoCD

- preprod (Citadel roadmvn) : pas de breaking change, ajout de champ pod-spec uniquement.
- prod (Citadel roadmvn) : idem.
- development/production overlays : non rattachés à ArgoCD Citadel, hardening utile pour lint Sonar.

Closes infra Security E -> A objectif partiel.