### PR TITLE
fix(security): retire SECRET_KEY_BASE en clair de notification prod (S6418)

### DIFF
--- a/k8s/whispr/production/notification-service/deployment.yaml
+++ b/k8s/whispr/production/notification-service/deployment.yaml
@@ -41,7 +41,10 @@ spec:
             - name: DATABASE_URL
               value: "postgresql://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
             - name: SECRET_KEY_BASE
-              value: "5NCXsMTyEFqQRqsWs8N6sWoH06ki+bXmuXlFffKq8Q5Lhmo21mf2SDDjt1Uhqocw"
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-app-secret
+                  key: SECRET_KEY_BASE
           envFrom:
             - configMapRef:
                 name: notification-service-config

--- a/k8s/whispr/production/notification-service/vault-app-secret.yaml
+++ b/k8s/whispr/production/notification-service/vault-app-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: notification-service-app-secret
+  namespace: whispr-prod
+spec:
+  vaultAuthRef: notification-service-vault-auth
+  mount: kv
+  type: kv-v2
+  path: whispr/notification-service/app
+  destination:
+    name: notification-service-app-secret
+    create: true
+  refreshAfter: 1h


### PR DESCRIPTION
BLOCKER securitaire signale par SonarCloud (S6418).

Le manifest k8s/whispr/production/notification-service/deployment.yaml ligne 44 avait un `SECRET_KEY_BASE` Phoenix hardcode en clair dans le repo public. Cette cle signe les cookies et tokens de session.

La valeur en cours doit etre consideree compromise.

## Fix

- nouveau `VaultStaticSecret` `notification-service-app-secret` qui pull `whispr/notification-service/app` depuis Vault vers un Secret k8s du meme nom
- l'env `SECRET_KEY_BASE` du deployment passe par `secretKeyRef` au lieu d'un literal

## A faire apres merge (manuel)

1. ecrire la nouvelle valeur (rotee, **PAS reutiliser l'ancienne**) dans Vault: 
   `vault kv put kv/whispr/notification-service/app SECRET_KEY_BASE=<nouveau_secret_64_chars>`
   Generer avec `mix phx.gen.secret` dans le repo notification-service
2. attendre le sync du VaultStaticSecret (refreshAfter 1h) ou forcer:
   `kubectl -n whispr-prod annotate vaultstaticsecret notification-service-app-secret secrets.hashicorp.com/v1beta1.refresh=$(date +%s) --overwrite`
3. rolling restart: `kubectl -n whispr-prod rollout restart deploy notification-service`
4. tous les utilisateurs connectes seront deconnectes - prevenir avant la rotation

Hors scope ici: faire pareil pour les autres services qui auraient un `SECRET_KEY_BASE` hardcode (a auditer avec un grep).