### PR TITLE
[WHISPR-1306] chore(deploy/messaging-service): manual bump to sha-ae9a16e (post fix CVE phoenix)

### DIFF
--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: messaging-service
-          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-6583311
+          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-ae9a16e
           ports:
             - name: http
               containerPort: 4010


### PR DESCRIPTION
## Summary

- Manual bump messaging-service preprod from sha-6583311 to sha-ae9a16e.
- Includes fix CVE GHSA-628h-q48j-jr6q (phoenix 1.7.23) plus PR #88 fanout message_deleted on user channel.
- CD broken upstream so manual bump needed to trigger ArgoCD sync.

## Validation

- [x] kubectl apply --dry-run=server clean on Citadel
- [ ] ArgoCD sync after merge
- [ ] Image kubectl confirmed live

Refs WHISPR-1305 WHISPR-1306