### PR TITLE
chore(deploy/messaging-service): bump to sha-ca56dfa for D read receipts gate (PR #91)

### DIFF
--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: messaging-service
-          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-ae9a16e
+          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-ca56dfa
           ports:
             - name: http
               containerPort: 4010


### PR DESCRIPTION
## Summary
- Bump messaging-service preprod image from sha-ae9a16e to sha-ca56dfa
- Deploys D read receipts gate (messaging-service PR #91 merged)
- CD pipeline cassee (token 403), bump manuel pour deployer le fix

## Validation
- [x] CI Pipeline messaging-service ca56dfa green (run 25590566904)
- [x] Image ghcr.io/.../messaging-service:sha-ca56dfa publiee
- [x] kubectl apply --dry-run=client OK sur le cluster preprod
- [ ] ArgoCD sync vers whispr-preprod ns (post-merge)
- [ ] Pods 3/3 Running apres rollout

Closes WHISPR-1310