### PR TITLE
chore(deploy/messaging-service): bump to sha-f7ddc88 for broadcast fanout fixes (PR #92)

### DIFF
--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: messaging-service
-          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-ca56dfa
+          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-f7ddc88
           ports:
             - name: http
               containerPort: 4010


### PR DESCRIPTION
## Summary
- Bump messaging-service image from sha-ca56dfa to sha-f7ddc88
- Includes broadcast fanout asymmetry fixes (read_receipt, edit, delete, reaction) merged via messaging-service PR #92
- PR #93 on messaging-service was a CLAUDE.md docs change only and is excluded by ci.yml `paths-ignore: '**.md'`, so no new image was built for sha-27fed7a; sha-f7ddc88 already contains all the code changes

## Validation
- [x] `kubectl apply --dry-run=client` passes against the preprod cluster
- [ ] ArgoCD sync succeeds and pods roll out

Closes WHISPR-1312