### PR TITLE
chore(deploy/messaging-service): bump to sha-5a7e8c4 for audit fixes (PR #94)

### DIFF
--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: messaging-service
-          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-f7ddc88
+          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-5a7e8c4
           ports:
             - name: http
               containerPort: 4010


### PR DESCRIPTION
## Summary
- Bump messaging-service preprod image from sha-f7ddc88 to sha-5a7e8c4
- Picks up audit findings fixes merged in messaging-service PR #94 (WHISPR-1315)
- CD pipeline messaging cassé (token 403), bump manuel

## Validation
- [x] CI green sur messaging-service deploy/preprod sha-5a7e8c4 (run 25591892878)
- [x] Image sha-5a7e8c4 publiée sur ghcr.io
- [x] kubectl apply --dry-run=client OK
- [ ] ArgoCD sync verifié post-merge
- [ ] kubectl get deploy messaging-service confirme image sha-5a7e8c4

Closes WHISPR-1316