### PR TITLE
fix(k8s): remove JWT private key from Git, harden pod security contexts

### DIFF
--- a/helm/citadel-overrides/nginx-ingress-values.yaml
+++ b/helm/citadel-overrides/nginx-ingress-values.yaml
@@ -5,6 +5,19 @@ controller:
     nodePorts:
       http: 30080
       https: 30443
+  config:
+    # Restreint la confiance X-Forwarded-For au seul noeud Citadel (Tailscale).
+    # 0.0.0.0/0 (valeur globale) permettrait a n'importe quel client de forger
+    # son IP source via ce header - vecteur de bypass de rate-limiting.
+    proxy-real-ip-cidr: "100.123.120.92/32"
+    use-forwarded-headers: "true"
+    enable-real-ip: "true"
+    # TLS 1.2 minimum - desactive TLS 1.0 et 1.1 (deprecated RFC 8996).
+    ssl-protocols: "TLSv1.2 TLSv1.3"
+    # HSTS 1 an avec preload pour les domaines publics Citadel.
+    hsts: "true"
+    hsts-max-age: "31536000"
+    hsts-include-subdomains: "true"
   resources:
     requests:
       cpu: 100m

--- a/k8s/whispr/preprod/auth-service/deployment.yaml
+++ b/k8s/whispr/preprod/auth-service/deployment.yaml
@@ -18,10 +18,21 @@ spec:
         app: auth-service
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: auth-service
           image: ghcr.io/whispr-messenger/auth-service/auth-service:sha-1b73612
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
           ports:
             - name: http
               containerPort: 3010

--- a/k8s/whispr/preprod/calls-service/deployment.yaml
+++ b/k8s/whispr/preprod/calls-service/deployment.yaml
@@ -17,12 +17,24 @@ spec:
       labels:
         app: calls-service
     spec:
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-calls
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: calls-service
           image: ghcr.io/whispr-messenger/calls-service:sha-c257fc9
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
           ports:
             - name: http
               containerPort: 4012

--- a/k8s/whispr/preprod/infra/jwt-keys.yaml
+++ b/k8s/whispr/preprod/infra/jwt-keys.yaml
@@ -1,18 +1,33 @@
+---
+# JWT signing keys for auth-service.
+#
+# The real key pair is provisioned out-of-band via kubectl (or Vault projection)
+# and MUST NOT be committed to Git.  We declare only the Secret shell here
+# (metadata + type, no stringData) so ArgoCD can reconcile metadata without
+# taking ownership of the key material.  ServerSideApply ensures the
+# kubectl-applied data field survives every ArgoCD sync.
+#
+# Bootstrap / rotate (run both; rolling-restart auth-service after):
+#
+#   openssl ecparam -name prime256v1 -genkey -noout \
+#     | openssl pkcs8 -topk8 -nocrypt -out /tmp/jwt_private.pem
+#   openssl ec -in /tmp/jwt_private.pem -pubout -out /tmp/jwt_public.pem
+#
+#   kubectl -n whispr-preprod create secret generic jwt-keys \
+#     --from-file=jwt_private.pem=/tmp/jwt_private.pem \
+#     --from-file=jwt_public.pem=/tmp/jwt_public.pem \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+#   rm /tmp/jwt_private.pem /tmp/jwt_public.pem
+#
+# The data keys MUST be "jwt_private.pem" and "jwt_public.pem" - the Deployment
+# mounts the Secret at /app/secrets and auth-service reads those exact filenames.
 apiVersion: v1
 kind: Secret
 metadata:
   name: jwt-keys
   namespace: whispr-preprod
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: ServerSideApply=true
 type: Opaque
-stringData:
-  jwt_private.pem: |
-    -----BEGIN PRIVATE KEY-----
-    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgHsf9dwYN2HGRxFvB
-    aU0E3vGek/qB8Tm03A1iZL1bBZ+hRANCAATV FCY2BF5cv+tbNdOMzDWJAqofvtDx
-    8xEf8nB4jBejIDAOT/3L2uXhcxmoOGcwvI9SvXkzSZGHdmd2Tz0d1rrc
-    -----END PRIVATE KEY-----
-  jwt_public.pem: |
-    -----BEGIN PUBLIC KEY-----
-    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1RQmNgReXL/rWzXTjMw1iQKqH77Q
-    8fMRH/JweIwXoyAwDk/9y9rl4XMZqDhnMLyPUr15M0mRh3Zndk89Hda63A==
-    -----END PUBLIC KEY-----

--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -18,9 +18,20 @@ spec:
         app: messaging-service
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: messaging-service
           image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-5a7e8c4
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
           ports:
             - name: http
               containerPort: 4010
@@ -50,3 +61,27 @@ spec:
             limits:
               memory: 512Mi
               cpu: 500m
+          # WHISPR-1329 : probes manquants - ajout des 3 pour éviter le trafic
+          # vers un pod non prêt et détecter les deadlocks runtime Elixir/Phoenix.
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: 4010
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 4010
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 4010
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s/whispr/preprod/notification-service/deployment.yaml
+++ b/k8s/whispr/preprod/notification-service/deployment.yaml
@@ -18,10 +18,21 @@ spec:
         app: notification-service
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: notification-service
           image: ghcr.io/whispr-messenger/notification-service:sha-8d08a35
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
           ports:
             - name: http
               containerPort: 4011
@@ -48,6 +59,30 @@ spec:
             - name: apns-key
               mountPath: /etc/apns
               readOnly: true
+          # WHISPR-1329 : probes manquants - couvre le warm-up Kadabra/Phoenix
+          # et détecte les deadlocks FCM/APNs.
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: 4011
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 4011
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 4011
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: apns-key
           secret:


### PR DESCRIPTION
## Summary

- Remove ECDSA private key committed in cleartext from `jwt-keys.yaml` (Critical - secret-in-Git); replace with empty Secret shell + ServerSideApply pattern matching apns-secret/fcm-secret conventions already in place
- Add pod + container securityContext to auth-service, calls-service, messaging-service, notification-service: `runAsNonRoot`, `runAsUser/Group 1000`, `seccompProfile RuntimeDefault`, `allowPrivilegeEscalation false`, `readOnlyRootFilesystem`, `capabilities.drop ALL`
- Add `automountServiceAccountToken: false` to calls-service (was missing)
- Add startup/liveness/readiness probes to messaging-service and notification-service (both had zero health probes)
- Restrict nginx `proxy-real-ip-cidr` from `0.0.0.0/0` to `100.123.120.92/32` (Citadel node only) to prevent X-Forwarded-For header spoofing for rate-limit bypass
- Enable HSTS 1y + includeSubdomains and enforce TLS 1.2+ minimum on Citadel nginx override

## Validation

- [ ] YAML syntax validated (python3 read, all 6 files structurally valid)
- [ ] `kubectl apply --dry-run=client` blocked by no local cluster - validate on preprod after merge
- [ ] JWT key must be re-bootstrapped on preprod before ArgoCD sync (see comment in jwt-keys.yaml)
- [ ] readOnlyRootFilesystem may require emptyDir volumes if services write to /tmp - verify in pod logs post-deploy

## Post-merge actions required

1. Rotate the JWT key pair on preprod (key was exposed in Git history):
   `openssl ecparam -name prime256v1 -genkey -noout | openssl pkcs8 -topk8 -nocrypt -out /tmp/jwt_private.pem && openssl ec -in /tmp/jwt_private.pem -pubout -out /tmp/jwt_public.pem && kubectl -n whispr-preprod create secret generic jwt-keys --from-file=jwt_private.pem=/tmp/jwt_private.pem --from-file=jwt_public.pem=/tmp/jwt_public.pem --dry-run=client -o yaml | kubectl apply -f -`
2. Rolling restart auth-service after key rotation
3. Monitor pod logs for readOnlyRootFilesystem errors (EROFS) - add emptyDir mounts if needed

Closes WHISPR-1329