### PR TITLE
chore(ci): add permissions blocks and pin actions to SHA

### DIFF
--- a/.github/workflows/cd-vault-config-job.yml
+++ b/.github/workflows/cd-vault-config-job.yml
@@ -30,13 +30,13 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with:
           app_id: ${{ secrets.ACTIONS_CD }}
           private_key: ${{ secrets.ACTIONS_CD_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,12 @@ name: Actions Runner Controller Demo
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   Explore-GitHub-Actions:
     runs-on: arc-runner-set
+    permissions:
+      contents: read
     steps:
-    - run: echo "🎉 This job uses runner scale set runners!"
+    - run: echo "This job uses runner scale set runners!"

--- a/.github/workflows/sync-preprod.yml
+++ b/.github/workflows/sync-preprod.yml
@@ -7,11 +7,15 @@ on:
       - 'k8s/whispr/preprod/**'
       - 'k8s/whispr/prod/**'
 
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,13 +34,13 @@ jobs:
             if git merge origin/main --no-edit; then
               echo "Merge succeeded cleanly"
             else
-              echo "Merge conflict detected — auto-resolving with main's version"
+              echo "Merge conflict detected - auto-resolving with main's version"
               git checkout --theirs .
               git add -A
               git commit --no-edit
             fi
           else
-            echo "deploy/preprod does not exist yet — creating from main"
+            echo "deploy/preprod does not exist yet - creating from main"
             git checkout -b deploy/preprod origin/main
           fi
 

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -6,11 +6,16 @@ on:
       - '**.tf'
       - '.github/workflows/terraform-ci.yml'
 
+permissions: {}
+
 jobs:
 
   terraform:
     name: Terraform Checks
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     env:
       TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
@@ -29,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive


### PR DESCRIPTION
## Summary
- `sync-preprod.yml`, `terraform-ci.yml`, `main.yml`: no permissions block = default GITHUB_TOKEN has write-all scope
- Added `permissions: {}` at workflow level + least-privilege at job level (contents:read or contents:write only where needed)
- `tibdex/github-app-token@v2` pinned to SHA in cd-vault-config-job.yml
- `actions/checkout@v4` and `hashicorp/setup-terraform@v3` pinned to SHA

## Test plan
- [ ] CI passes
- [ ] sync-preprod still merges correctly on next push to main
- [ ] terraform-ci still validates on next PR touching .tf files
- [ ] cd-vault-config-job still generates token and pushes image bump

Closes WHISPR-1333