### PR TITLE
[WHISPR-1329] fix(k8s/preprod/messaging): aligne probes sur /live et /ready

### DIFF
--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -63,15 +63,17 @@ spec:
               cpu: 500m
           # WHISPR-1329 : probes manquants - ajout des 3 pour éviter le trafic
           # vers un pod non prêt et détecter les deadlocks runtime Elixir/Phoenix.
+          # paths /live et /ready exposés à la racine par WhisprMessagingWeb.Router
+          # (le scope /messaging/api/v1/health/* existe aussi mais probes preferent root).
           startupProbe:
             httpGet:
-              path: /health/live
+              path: /live
               port: 4010
             failureThreshold: 30
             periodSeconds: 2
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: /live
               port: 4010
             initialDelaySeconds: 30
             periodSeconds: 20
@@ -79,7 +81,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health/ready
+              path: /ready
               port: 4010
             initialDelaySeconds: 10
             periodSeconds: 10


### PR DESCRIPTION
## Probleme

Les pods messaging-service en preprod tournent en boucle de restart (5+ restarts en quelques minutes). Le pod healthy `cv44d` (RS ancienne sans probes) tourne depuis 6h, mais les nouveaux pods crees apres ajout des probes (commit WHISPR-1329) sont kill par kubelet.

Logs des nouveaux pods :
\`\`\`
GET /health/live -> Phoenix.Router.NoRouteError -> 404
\`\`\`

## Cause racine

Image deployee \`sha-5a7e8c4\` expose ces routes a la racine :
- \`/live\` (HealthController.live)
- \`/ready\` (HealthController.ready)

Et ces routes sous le scope \`/messaging/api/v1\` :
- \`/messaging/api/v1/health/live\`
- \`/messaging/api/v1/health/ready\`

Mais probes WHISPR-1329 hit \`/health/live\` et \`/health/ready\` qui n'existent nulle part dans le router. Probe failure permanente -> CrashLoopBackOff.

## Fix

Aligner les paths des 3 probes (startup, liveness, readiness) sur ce que le router expose actuellement : \`/live\` et \`/ready\` (root).

## Test plan

- [x] dry-run YAML clean
- [ ] ArgoCD-preprod-citadel sync OK apres merge
- [ ] Pods messaging-service passent 1/1 Ready (plus de restart loop)
- [ ] \`kubectl exec\` curl \`/live\` -> 200