### PR TITLE
[WHISPR-1340] fix(k8s/preprod/notification): ajouter probes startup/liveness/readiness manquants

### DIFF
--- a/k8s/whispr/preprod/notification-service/deployment.yaml
+++ b/k8s/whispr/preprod/notification-service/deployment.yaml
@@ -43,6 +43,30 @@ spec:
             limits:
               memory: 384Mi
               cpu: 500m
+          # WHISPR-1340 : ajout des probes manquants pour que k8s detecte
+          # les hangs/deadlocks et restart le pod automatiquement.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 4011
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 4011
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 4011
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: apns-key
               mountPath: /etc/apns


### PR DESCRIPTION
## Summary

- Ajoute les probes `startupProbe`, `livenessProbe` et `readinessProbe` au deployment k8s preprod de `notification-service`
- Avant ce fix le deployment n'avait aucune probe : si l'app deadlock ou hang, k8s ne detecte rien et ne redemarre pas le pod
- Les 3 probes pointent sur `/api/v1/health` port `4011` (path verifie en live via `kubectl exec` -> retourne 200 `{"status":"ok"}`)
- Alignement avec le pattern des autres services preprod (auth, messaging, calls, moderation)

## Test plan

- [x] `curl http://localhost:4011/api/v1/health` depuis le pod -> 200 OK `{"status":"ok"}`
- [x] `kubectl apply --dry-run=server` clean
- [x] YAML parse OK
- [ ] ArgoCD sync `Synced/Healthy` apres merge
- [ ] Pod `1/1 Ready` apres rollout

Closes WHISPR-1340