### PR TITLE
[WHISPR-1341] feat(k8s/preprod/messaging): enable WHISPR_ALLOW_HTTP_JWKS + re-bump

### DIFF
--- a/k8s/whispr/preprod/messaging-service/configmap.yaml
+++ b/k8s/whispr/preprod/messaging-service/configmap.yaml
@@ -8,3 +8,7 @@ data:
   JWT_AUDIENCE: "whispr-api"
   USER_SERVICE_HTTP_URL: "http://user-service:3011"
   ADMIN_USER_IDS: "3378ee73-ce43-4145-b689-ba982d97721e,fab8817a-27a0-4537-89c1-be05f783150b"
+  # WHISPR-1341 : autorise http:// pour JWT_JWKS_URL en MIX_ENV=prod car
+  # auth-service est joint via DNS k8s interne (cluster-internal, HTTP legitime).
+  # NE PAS activer en prod publique.
+  WHISPR_ALLOW_HTTP_JWKS: "true"

--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: messaging-service
-          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-5a7e8c4
+          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-7527288
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

Complement de la PR https://github.com/whispr-messenger/messaging-service/pull/100 (mergee, sha-7527288) qui ajoute l'override `WHISPR_ALLOW_HTTP_JWKS=true`. Cette PR :

1. Active la var d'env dans le configmap `messaging-service-config` du namespace `whispr-preprod` UNIQUEMENT.
2. Re-bump l'image vers `sha-7527288` (merge commit de WHISPR-1341 messaging).

## Contexte

- WHISPR-1241 (`ce6f9f5`) a introduit un check HTTPS strict au boot quand `MIX_ENV=prod`.
- Preprod tourne `MIX_ENV=prod` mais joint auth-service via `http://auth-service:3010` (DNS k8s interne).
- Resultat : tous les bumps post-WHISPR-1241 partent en CrashLoopBackOff. Le bump `db8d861e` a ete rollback en `51c09e19` pour stabiliser preprod.
- 5 fixes deja merges sont bloques : WHISPR-1239, WHISPR-847+843, WHISPR-845, WHISPR-848.

L'image `sha-7527288` contient le validator qui sait lire `WHISPR_ALLOW_HTTP_JWKS`. La var dans le configmap rend l'override effectif.

## NE PAS appliquer en prod publique

Le configmap prod (`k8s/whispr/prod/...` quand il existera) ne doit PAS avoir cette var : la prod publique doit garder le check HTTPS strict.

## Validation

- [x] `kubectl apply --dry-run=server` clean sur configmap + deployment (via Citadel)
- [x] Diff revue : seuls preprod messaging touches, pas de prod
- [ ] Apres merge : ArgoCD sync + verifier pods 1/1 Ready

Closes WHISPR-1341