### PR TITLE
[WHISPR-1354] feat(k8s/calls-service): add CORS_ALLOWED_ORIGINS

### DIFF
--- a/k8s/whispr/preprod/calls-service/deployment.yaml
+++ b/k8s/whispr/preprod/calls-service/deployment.yaml
@@ -102,6 +102,12 @@ spec:
                   name: calls-preprod-secrets
                   key: messaging_service_token
                   optional: true
+            # WHISPR-1354 : whitelist des origins autorisees pour le WebSocket
+            # /calls/ws (signaling LiveKit). En prod, runtime.exs override
+            # check_origin pour appeler ws_check_origin/1 qui lit cette var.
+            # Si la var est absente/vide/wildcard, le boot raise (fail-closed).
+            - name: CORS_ALLOWED_ORIGINS
+              value: "https://whispr-preprod.roadmvn.com,https://preprod-whispr-api.roadmvn.com,https://whispr-api.roadmvn.com"
           resources:
             requests:
               memory: 512Mi


### PR DESCRIPTION
## Summary

Ajoute `CORS_ALLOWED_ORIGINS` au deployment k8s preprod calls-service. La PR app calls-service (#10) active `ws_check_origin/1` via MFA en prod : sans cette var, le boot raise (fail-closed).

Whitelist preprod = PWA + API publiques, alignee avec la valeur deja set sur messaging-service.

## Validation

- [x] kubectl apply --dry-run=server clean (via VPS Citadel)
- [x] Valeur identique a messaging-service-env.CORS_ALLOWED_ORIGINS

## Sequencement

A merger **apres** calls-service PR #10 (sinon le pod boot raise sur version actuelle qui ignore la var). Apres merge ici, ArgoCD sync deployment, kubectl rollout restart calls-service pour picker la nouvelle var.

Closes WHISPR-1354