### PR TITLE
[WHISPR-1369] fix(infra): livekit secret + hostNetwork + securityContext preprod

### DIFF
--- a/k8s/whispr/preprod/livekit/helm-values.yaml
+++ b/k8s/whispr/preprod/livekit/helm-values.yaml
@@ -31,6 +31,10 @@ image:
   repository: livekit/livekit-server
   pullPolicy: IfNotPresent
 
+# Desactive pour eviter qu'un container compromis sniffe le trafic node
+# et bypasse les NetworkPolicies. Les ports RTC sont exposes via NodePort.
+podHostNetwork: false
+
 livekit:
   port: 7880
   log_level: info
@@ -49,18 +53,14 @@ livekit:
   # it back on once the cert is provisioned.
   turn:
     enabled: false
-  # Placeholder API keys. The admin MUST override these via the ArgoCD
-  # Application helm.parameters block or by patching the generated
-  # `livekit-server` ConfigMap after the first sync. Real keys also need
-  # to be mirrored into the calls-service secret so backend and SFU
-  # agree on the key pair.
-  keys:
-    REPLACE_ME: REPLACE_ME_WITH_REAL_SECRET
+  # Aucune cle reelle committee en git. Le ConfigMap livekit-server est patche
+  # out-of-band par l'admin apres le premier sync ArgoCD (voir README.md).
+  # ignoreDifferences dans livekit.yaml empeche ArgoCD de revenir a {} au selfHeal.
+  keys: {}
 
 loadBalancer:
   # ClusterIP-only Service for the HTTP API (exposed via nginx Ingress in
-  # ingress.yaml). RTC TCP/UDP are published via hostPort + hostNetwork
-  # on the node (chart default podHostNetwork: true).
+  # ingress.yaml). RTC TCP/UDP sont exposes via NodePort dedie.
   type: disable
 
 resources:

--- a/k8s/whispr/preprod/media-service/deployment.yaml
+++ b/k8s/whispr/preprod/media-service/deployment.yaml
@@ -64,6 +64,7 @@ spec:
             requests:
               memory: 128Mi
               cpu: 100m
+              ephemeralStorage: 256Mi
             limits:
               memory: 384Mi
               cpu: 500m

--- a/k8s/whispr/preprod/media-service/deployment.yaml
+++ b/k8s/whispr/preprod/media-service/deployment.yaml
@@ -102,4 +102,5 @@ spec:
               mountPath: /tmp
       volumes:
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 512Mi

--- a/k8s/whispr/preprod/media-service/deployment.yaml
+++ b/k8s/whispr/preprod/media-service/deployment.yaml
@@ -18,9 +18,21 @@ spec:
         app: media-service
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: media-service
           image: ghcr.io/whispr-messenger/media-service/media-service:sha-2585255
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
           ports:
             - name: http
               containerPort: 3012
@@ -55,7 +67,7 @@ spec:
             limits:
               memory: 384Mi
               cpu: 500m
-          # WHISPR-1065 : startupProbe laisse le temps au démarrage (Vault
+          # WHISPR-1065 : startupProbe laisse le temps au demarrage (Vault
           # handshake + S3 sanity) avant de solliciter le livenessProbe.
           startupProbe:
             httpGet:
@@ -79,3 +91,11 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+          volumeMounts:
+            # readOnlyRootFilesystem=true : NestJS peut ecrire dans /tmp (upload temp,
+            # multipart). Ce volume emptyDir donne un /tmp writable en RAM.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/whispr/preprod/media-service/deployment.yaml
+++ b/k8s/whispr/preprod/media-service/deployment.yaml
@@ -67,6 +67,9 @@ spec:
             limits:
               memory: 384Mi
               cpu: 500m
+              # borne le stockage ephemere pour que les uploads temporaires NestJS dans /tmp
+              # ne saturent pas le noeud
+              ephemeralStorage: 512Mi
           # WHISPR-1065 : startupProbe laisse le temps au demarrage (Vault
           # handshake + S3 sanity) avant de solliciter le livenessProbe.
           startupProbe:

--- a/k8s/whispr/preprod/moderation-service/deployment.yaml
+++ b/k8s/whispr/preprod/moderation-service/deployment.yaml
@@ -78,6 +78,7 @@ spec:
             requests:
               memory: 512Mi
               cpu: 250m
+              ephemeralStorage: 256Mi
             limits:
               memory: 1Gi
               cpu: 500m

--- a/k8s/whispr/preprod/moderation-service/deployment.yaml
+++ b/k8s/whispr/preprod/moderation-service/deployment.yaml
@@ -19,10 +19,22 @@ spec:
         app: moderation-service
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: moderation-service
           image: ghcr.io/whispr-messenger/moderation-service:preprod
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
           ports:
             - name: http
               containerPort: 8000
@@ -38,7 +50,7 @@ spec:
               value: "10"
             - name: MOD_RATE_LIMIT
               value: "30/minute"
-          # WHISPR-1065 : startupProbe couvre le chargement du modèle (plusieurs
+          # WHISPR-1065 : startupProbe couvre le chargement du modele (plusieurs
           # dizaines de secondes au cold start) avant d'activer le livenessProbe.
           startupProbe:
             httpGet:
@@ -69,3 +81,11 @@ spec:
             limits:
               memory: 1Gi
               cpu: 500m
+          volumeMounts:
+            # readOnlyRootFilesystem=true : NudeNet ecrit son model cache dans /tmp.
+            # Ce volume emptyDir donne un /tmp writable sans monter le FS racine.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/whispr/preprod/moderation-service/deployment.yaml
+++ b/k8s/whispr/preprod/moderation-service/deployment.yaml
@@ -92,4 +92,5 @@ spec:
               mountPath: /tmp
       volumes:
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 512Mi

--- a/k8s/whispr/preprod/moderation-service/deployment.yaml
+++ b/k8s/whispr/preprod/moderation-service/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             limits:
               memory: 1Gi
               cpu: 500m
+              # borne le stockage ephemere pour que le model cache NudeNet dans /tmp
+              # ne sature pas le noeud en cas de chargement en boucle
+              ephemeralStorage: 512Mi
           volumeMounts:
             # readOnlyRootFilesystem=true : NudeNet ecrit son model cache dans /tmp.
             # Ce volume emptyDir donne un /tmp writable sans monter le FS racine.

--- a/k8s/whispr/preprod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/preprod/scheduling-service/deployment.yaml
@@ -18,9 +18,21 @@ spec:
         app: scheduling-service
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: scheduling-service
           image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-8d83a20
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
           ports:
             - name: http
               containerPort: 3013
@@ -43,9 +55,9 @@ spec:
             limits:
               memory: 384Mi
               cpu: 500m
-          # WHISPR-1065 : startupProbe évite le livenessProbe prématuré pendant
+          # WHISPR-1065 : startupProbe evite le livenessProbe premature pendant
           # le warm-up (Nest + TypeORM). failureThreshold * periodSeconds
-          # = 60 s max avant abandon du démarrage.
+          # = 60 s max avant abandon du demarrage.
           startupProbe:
             httpGet:
               path: /health
@@ -68,3 +80,11 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+          volumeMounts:
+            # readOnlyRootFilesystem=true : NestJS ecrit dans /tmp (jobs temp, caches
+            # runtime). Ce volume emptyDir donne un /tmp writable en RAM.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/whispr/preprod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/preprod/scheduling-service/deployment.yaml
@@ -91,4 +91,5 @@ spec:
               mountPath: /tmp
       volumes:
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 256Mi

--- a/k8s/whispr/preprod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/preprod/scheduling-service/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             limits:
               memory: 384Mi
               cpu: 500m
+              # borne le stockage ephemere pour que les jobs temporaires NestJS dans /tmp
+              # ne saturent pas le noeud en cas de crash en boucle
+              ephemeralStorage: 256Mi
           # WHISPR-1065 : startupProbe evite le livenessProbe premature pendant
           # le warm-up (Nest + TypeORM). failureThreshold * periodSeconds
           # = 60 s max avant abandon du demarrage.

--- a/k8s/whispr/preprod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/preprod/scheduling-service/deployment.yaml
@@ -52,6 +52,7 @@ spec:
             requests:
               memory: 128Mi
               cpu: 100m
+              ephemeralStorage: 128Mi
             limits:
               memory: 384Mi
               cpu: 500m


### PR DESCRIPTION
## Summary
- **livekit helm-values**: retire `REPLACE_ME` des `keys` (remplace par `keys: {}`), ajoute `podHostNetwork: false` pour bloquer le sniffing trafic node
- **moderation-service**: ajoute `securityContext` pod + container (runAsNonRoot, readOnlyRootFilesystem, drop ALL), emptyDir `/tmp` pour NudeNet model cache
- **media-service**: meme securityContext, emptyDir `/tmp` pour NestJS upload temp
- **scheduling-service**: meme securityContext, emptyDir `/tmp` pour NestJS runtime

## Validation
- [x] YAML syntaxe validee (aucun tab, indentation correcte)
- [x] `git diff` relu - pas de breaking change sur les routes/probes existantes
- [x] Identite roadman confirmee sur le commit

## Notes
- livekit: `ignoreDifferences` dans `livekit.yaml` empeche le selfHeal de revenir a `keys: {}` - le patch out-of-band reste intact
- moderation: `runAsUser: 1000` - a verifier que le Dockerfile NudeNet tourne bien en non-root (si crash au startup, ouvrir un ticket pour ajuster l'image)

Closes WHISPR-1369