### PR TITLE
[WHISPR-1375] fix(k8s): env vars FCM (notif) + NOTIFICATION_SERVICE_* (auth) preprod

### DIFF
--- a/k8s/whispr/preprod/auth-service/configmap.yaml
+++ b/k8s/whispr/preprod/auth-service/configmap.yaml
@@ -6,3 +6,5 @@ metadata:
 data:
   JWT_ISSUER: "https://auth.whispr.roadmvn.com"
   JWT_AUDIENCE: "whispr-api"
+  NOTIFICATION_SERVICE_HOST: "notification-service.whispr-preprod.svc.cluster.local"
+  NOTIFICATION_SERVICE_PORT: "4011"

--- a/k8s/whispr/preprod/notification-service/configmap.yaml
+++ b/k8s/whispr/preprod/notification-service/configmap.yaml
@@ -8,3 +8,6 @@ data:
   APNS_KEY_ID: ""
   APNS_TEAM_ID: ""
   APNS_MODE: "dev"
+  # FCM_PROJECT_ID : remplacer par le project ID Firebase exact (visible dans la console Firebase > Paramètres du projet)
+  FCM_PROJECT_ID: "whispr-messenger"
+  FCM_JSON_KEYFILE: "/etc/fcm/keyfile.json"

--- a/k8s/whispr/preprod/notification-service/deployment.yaml
+++ b/k8s/whispr/preprod/notification-service/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - name: apns-key
               mountPath: /etc/apns
               readOnly: true
+            - name: fcm-key
+              mountPath: /etc/fcm
+              readOnly: true
       volumes:
         - name: apns-key
           secret:
@@ -54,4 +57,11 @@ spec:
             items:
               - key: AuthKey.p8
                 path: AuthKey.p8
+            optional: true
+        - name: fcm-key
+          secret:
+            secretName: notification-fcm-keyfile
+            items:
+              - key: keyfile.json
+                path: keyfile.json
             optional: true


### PR DESCRIPTION
## Summary
- Ajoute `FCM_PROJECT_ID` et `FCM_JSON_KEYFILE` dans `notification-service-config` (configmap preprod) — FCM etait silencieusement desactive faute de ces vars
- Monte le secret `notification-fcm-keyfile` sous `/etc/fcm` dans le deployment notification-service (`optional: true`, pattern identique APNs) pour que le keyfile soit accessible au runtime
- Ajoute `NOTIFICATION_SERVICE_HOST` et `NOTIFICATION_SERVICE_PORT=4011` dans `auth-service-config` (configmap preprod) — auth-service ne pouvait pas joindre notification-service

## Validation
- [x] YAML syntaxiquement valide (pas de tabs, structure apiVersion/kind presente)
- [x] Dry-run impossible localement (pas de kubeconfig preprod) - ArgoCD validera au sync
- [ ] ArgoCD sync auth-service + notification-service a verifier apres merge

## Action manuelle requise apres merge
Le secret FCM doit etre cree sur le cluster s'il n'existe pas encore :
```bash
kubectl create secret generic notification-fcm-keyfile \
  --from-file=keyfile.json=/path/to/firebase-adminsdk.json \
  -n whispr-preprod
```
Le `FCM_PROJECT_ID` dans le configmap est positionne a `whispr-messenger` - confirmer avec la console Firebase si la valeur exacte differe.

Closes WHISPR-1375