### PR TITLE
[WHISPR-1377] fix(k8s): prod imagePullPolicy IfNotPresent + PDB par service

### DIFF
--- a/k8s/whispr/preprod/auth-service/pdb.yaml
+++ b/k8s/whispr/preprod/auth-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-service-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: auth-service

--- a/k8s/whispr/preprod/media-service/pdb.yaml
+++ b/k8s/whispr/preprod/media-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: media-service-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: media-service

--- a/k8s/whispr/preprod/messaging-service/pdb.yaml
+++ b/k8s/whispr/preprod/messaging-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: messaging-service-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: messaging-service

--- a/k8s/whispr/preprod/mobile-web/pdb.yaml
+++ b/k8s/whispr/preprod/mobile-web/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mobile-web-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: mobile-web

--- a/k8s/whispr/preprod/moderation-service/pdb.yaml
+++ b/k8s/whispr/preprod/moderation-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: moderation-service-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: moderation-service

--- a/k8s/whispr/preprod/notification-service/pdb.yaml
+++ b/k8s/whispr/preprod/notification-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notification-service-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: notification-service

--- a/k8s/whispr/preprod/scheduling-service/pdb.yaml
+++ b/k8s/whispr/preprod/scheduling-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: scheduling-service-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: scheduling-service

--- a/k8s/whispr/preprod/user-service/pdb.yaml
+++ b/k8s/whispr/preprod/user-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: user-service-pdb
+  namespace: whispr-preprod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: user-service

--- a/k8s/whispr/prod/auth-service/pdb.yaml
+++ b/k8s/whispr/prod/auth-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-service-pdb
+  namespace: whispr-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: auth-service

--- a/k8s/whispr/prod/media-service/pdb.yaml
+++ b/k8s/whispr/prod/media-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: media-service-pdb
+  namespace: whispr-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: media-service

--- a/k8s/whispr/prod/messaging-service/pdb.yaml
+++ b/k8s/whispr/prod/messaging-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: messaging-service-pdb
+  namespace: whispr-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: messaging-service

--- a/k8s/whispr/prod/mobile-web/deployment.yaml
+++ b/k8s/whispr/prod/mobile-web/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: mobile-web
           image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-4bd3396
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 3020

--- a/k8s/whispr/prod/mobile-web/pdb.yaml
+++ b/k8s/whispr/prod/mobile-web/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mobile-web-pdb
+  namespace: whispr-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: mobile-web

--- a/k8s/whispr/prod/moderation-service/pdb.yaml
+++ b/k8s/whispr/prod/moderation-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: moderation-service-pdb
+  namespace: whispr-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: moderation-service

--- a/k8s/whispr/prod/notification-service/deployment.yaml
+++ b/k8s/whispr/prod/notification-service/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: notification-service
           image: ghcr.io/whispr-messenger/notification-service:sha-19f80dd
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 4011

--- a/k8s/whispr/prod/notification-service/pdb.yaml
+++ b/k8s/whispr/prod/notification-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notification-service-pdb
+  namespace: whispr-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: notification-service

--- a/k8s/whispr/prod/user-service/pdb.yaml
+++ b/k8s/whispr/prod/user-service/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: user-service-pdb
+  namespace: whispr-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: user-service


### PR DESCRIPTION
## Summary
- `notification-service` et `mobile-web` prod : `imagePullPolicy: Always` -> `IfNotPresent` (images SHA-pinned, changement safe)
- Ajout `PodDisruptionBudget` (`maxUnavailable: 1`) sur 7 services prod : auth, media, messaging, mobile-web, moderation, notification, user
- Ajout `PodDisruptionBudget` (`maxUnavailable: 1`) sur 8 services preprod : idem + scheduling
- `scheduling-service` prod conserve son PDB existant dans `extra.yaml` (`minAvailable: 1` + HPA, deja couvert)
- `livekit` exclu (chart Helm gere son propre PDB)

## Validation
- [x] `kubectl apply --dry-run=client` sur VPS Citadel - OK sur PDB et deployments modifies
- [x] Images SHA-pinned verifiees avant changement `imagePullPolicy` (`sha-19f80dd`, `sha-4bd3396`)
- [x] Tous les services mono-replica -> `maxUnavailable: 1` (permet le drain, recreate par k8s)

Closes WHISPR-1377