### PR TITLE
[WHISPR-1400] fix(k8s): prod probes split liveness vs readiness + startupProbe Elixir + FCM expiry

### DIFF
--- a/k8s/whispr/preprod/notification-service/fcm-secret.yaml
+++ b/k8s/whispr/preprod/notification-service/fcm-secret.yaml
@@ -1,0 +1,28 @@
+---
+# Google Firebase service account key for notification-service FCM push (WHISPR-1400).
+#
+# The real keyfile.json is provisioned out-of-band via kubectl from Vault and
+# MUST NOT be committed to Git. We declare only the Secret shell here
+# (metadata + type, no data) and rely on ServerSideApply so that the data
+# field applied by kubectl is owned by the bootstrap, not by Git.
+#
+# Bootstrap command (rerun to rotate; rolling-restart the Deployment after):
+#
+#   kubectl -n whispr-preprod create secret generic notification-fcm-keyfile \
+#     --from-file=keyfile.json=/path/to/fcm-service-account.json \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# Google service account keys expire. Check expiry in Google Cloud console:
+#   https://console.cloud.google.com/iam-admin/serviceaccounts
+# Rotate yearly or immediately on suspected compromise.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: notification-fcm-keyfile
+  namespace: whispr-preprod
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+    whispr.io/expiry-date: "TBD - documenter date rotation Google service account"
+    whispr.io/rotation-policy: "yearly"
+type: Opaque

--- a/k8s/whispr/prod/auth-service/deployment.yaml
+++ b/k8s/whispr/prod/auth-service/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /auth/v1/health/ready
+              path: /auth/v1/health/live
               port: 3010
             initialDelaySeconds: 45
             periodSeconds: 30

--- a/k8s/whispr/prod/media-service/deployment.yaml
+++ b/k8s/whispr/prod/media-service/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /media/v1/health/ready
+              path: /media/v1/health/live
               port: 3012
             initialDelaySeconds: 45
             periodSeconds: 30

--- a/k8s/whispr/prod/messaging-service/deployment.yaml
+++ b/k8s/whispr/prod/messaging-service/deployment.yaml
@@ -28,16 +28,22 @@ spec:
           envFrom:
             - secretRef:
                 name: messaging-service-env
+          startupProbe:
+            httpGet:
+              path: /messaging/api/v1/live
+              port: 4010
+            failureThreshold: 15
+            periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /messaging/api/v1/health
+              path: /messaging/api/v1/ready
               port: 4010
             initialDelaySeconds: 20
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /messaging/api/v1/health
+              path: /messaging/api/v1/live
               port: 4010
             initialDelaySeconds: 45
             periodSeconds: 30

--- a/k8s/whispr/prod/notification-service/deployment.yaml
+++ b/k8s/whispr/prod/notification-service/deployment.yaml
@@ -28,6 +28,12 @@ spec:
           envFrom:
             - secretRef:
                 name: notification-service-env
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 4011
+            failureThreshold: 15
+            periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /api/v1/health

--- a/k8s/whispr/prod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/prod/scheduling-service/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /health/ready
+              path: /health/live
               port: 3013
             initialDelaySeconds: 45
             periodSeconds: 30

--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /user/v1/health/ready
+              path: /user/v1/health/live
               port: 3011
             initialDelaySeconds: 45
             periodSeconds: 30


### PR DESCRIPTION
## Summary

- Split `livenessProbe` off the readiness path onto `**/health/live` (process-only) for auth, user, media, scheduling prod — prevents Twilio/DB latency spikes from triggering pod restarts
- Split messaging-service probes: liveness → `/messaging/api/v1/live`, readiness → `/messaging/api/v1/ready`
- Add `startupProbe` (failureThreshold: 15, periodSeconds: 5 = 75s window) on messaging and notification prod Elixir deployments — covers the 15-30s BEAM boot without hitting the liveness threshold
- Add `preprod/notification-service/fcm-secret.yaml` shell with `whispr.io/expiry-date` and `whispr.io/rotation-policy: yearly` annotations for FCM key expiry tracking

## Paths verified against source code

| Service | liveness | readiness |
|---------|----------|-----------|
| auth | `/auth/v1/health/live` | `/auth/v1/health/ready` |
| user | `/user/v1/health/live` | `/user/v1/health/ready` |
| media | `/media/v1/health/live` | `/media/v1/health/ready` |
| scheduling | `/health/live` | `/health/ready` |
| messaging | `/messaging/api/v1/live` | `/messaging/api/v1/ready` |
| notification | `/api/v1/health` (already process-only) | `/api/v1/health` |

## Validation

- [x] YAML syntax validated (Ruby yaml.load_file) on all 7 files
- [x] Routes confirmed against health controller source (`@Get('live')`, `@Get('ready')`) for all NestJS services
- [x] Elixir router paths confirmed in `router.ex` for messaging and notification
- [x] `calls-service` absent from `k8s/whispr/prod/` - no file to modify
- [x] Git author: roadman only

Closes WHISPR-1400