### PR TITLE
[WHISPR-1407] fix(k8s): notif readinessProbe /api/v1/health/ready

### DIFF
--- a/k8s/whispr/preprod/notification-service/deployment.yaml
+++ b/k8s/whispr/preprod/notification-service/deployment.yaml
@@ -36,6 +36,26 @@ spec:
               value: postgresql.postgresql.svc.cluster.local
             - name: REDIS_HOST
               value: redis-master.redis.svc.cluster.local
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 4011
+            failureThreshold: 15
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health/ready
+              port: 4011
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 4011
+            initialDelaySeconds: 45
+            periodSeconds: 30
+            failureThreshold: 3
           resources:
             requests:
               memory: 128Mi

--- a/k8s/whispr/prod/notification-service/deployment.yaml
+++ b/k8s/whispr/prod/notification-service/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /api/v1/health
+              path: /api/v1/health/ready
               port: 4011
             initialDelaySeconds: 20
             periodSeconds: 10


### PR DESCRIPTION
## Summary

- prod: `readinessProbe.httpGet.path` passe de `/api/v1/health` a `/api/v1/health/ready` (check DB + Redis)
- preprod: ajout des 3 probes manquantes (startupProbe + readinessProbe + livenessProbe)
- liveness et startup restent sur `/api/v1/health` (process-only)
- suite directe de WHISPR-1403 (handler `/api/v1/health/ready` ajoute en notification-service PR #67)

## Validation

- [x] YAML valide (ruby YAML.load_stream, 0 erreur)
- [x] Diff scope: 2 fichiers uniquement (prod + preprod deployment.yaml)
- [x] Liveness et startup inchanges sur les 2 manifestes

## Abort criteria

- Si le handler `/api/v1/health/ready` n'est pas encore roule en preprod (image sha pas a jour avec WHISPR-1403), les pods notification-service deviennent unready apres merge - rollback PR immediatement.

Closes WHISPR-1407