### PR TITLE
[WHISPR-1424] fix(helm): promtail scrape pods k8s generiques

### DIFF
--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -6,6 +6,34 @@ config:
 
   snippets:
     extraScrapeConfigs: |
+      # Scrape tous les pods applicatifs sans sidecar istio-proxy
+      - job_name: kubernetes-pods
+        pipeline_stages:
+          - cri: {}
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          # Ignorer les pods avec sidecar istio-proxy (couverts par le job ci-dessous)
+          - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status]
+            action: drop
+            regex: .+
+          # Ignorer les pods non demarres
+          - source_labels: [__meta_kubernetes_pod_phase]
+            action: drop
+            regex: (Failed|Succeeded)
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+          - source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+            target_label: __path__
+            separator: /
+            replacement: /var/log/pods/*$1/*.log
+
       # Scrape Istio JSON access logs with json parsing
       - job_name: kubernetes-pods-istio
         kubernetes_sd_configs:


### PR DESCRIPTION
## Summary
- Ajoute `job_name: kubernetes-pods` dans `extraScrapeConfigs` de Promtail
- Scrape tous les pods k8s sans sidecar istio-proxy (calls-service, messaging-service, auth-service, notification-service, user-service, media-service)
- Exclut les pods avec annotation `sidecar.istio.io/status` via `action: drop` pour eviter les doublons avec le job `kubernetes-pods-istio` existant
- Exclut les pods `Failed`/`Succeeded` pour ne pas polluer

## Validation
- [x] YAML valid (ruby parser)
- [x] Structural checks passes (2 jobs presents, relabel_configs corrects)
- [x] 1 seul fichier modifie - scope minimal respecte

## Post-deploy
Verifier dans Grafana/Loki que `{namespace="whispr-preprod"}` retourne des logs des services applicatifs.

Closes WHISPR-1424