### PR TITLE
feat(k8s): NetworkPolicy default-deny + per-service allow rules

### DIFF
--- a/k8s/whispr/preprod/auth-service/network-policy.yaml
+++ b/k8s/whispr/preprod/auth-service/network-policy.yaml
@@ -1,0 +1,80 @@
+# NetworkPolicy pour auth-service (preprod).
+# Ingress : nginx-ingress (trafic externe) + notification-service ne l'appelle pas,
+#           mais auth l'appelle en sortie. On accepte aussi les appels internes
+#           (user, media, scheduling, messaging) pour la validation JWKS.
+# Egress  : postgres (5432), redis (6379), notification-service (4011 gRPC)
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: auth-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: auth-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis le controleur nginx-ingress (namespace ingress-nginx)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3010
+          protocol: TCP
+    # Trafic interne depuis les services whispr-preprod qui fetche le JWKS
+    - from:
+        - podSelector:
+            matchLabels:
+              app: user-service
+        - podSelector:
+            matchLabels:
+              app: media-service
+        - podSelector:
+            matchLabels:
+              app: scheduling-service
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+        - podSelector:
+            matchLabels:
+              app: moderation-service
+      ports:
+        - port: 3010
+          protocol: TCP
+    # gRPC interne (appels inter-service si necessaire)
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50010
+          protocol: TCP
+  egress:
+    # PostgreSQL (namespace postgresql)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (namespace redis)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # notification-service (envoi OTP push)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP

--- a/k8s/whispr/preprod/infra/network-policy-default-deny.yaml
+++ b/k8s/whispr/preprod/infra/network-policy-default-deny.yaml
@@ -1,0 +1,34 @@
+# Politique de refus par defaut pour le namespace whispr-preprod.
+# Tout trafic ingress ET egress est bloque sauf autorisation explicite par une
+# NetworkPolicy supplementaire. Le DNS (port 53) est autorise globalement via
+# la politique dns-egress-allow ci-dessous pour que la resolution de noms
+# de service k8s fonctionne.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: whispr-preprod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# Autorisation DNS sortant pour tous les pods du namespace.
+# Sans ca, kube-dns est inaccessible et les services ne peuvent pas se resoudre.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: whispr-preprod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP

--- a/k8s/whispr/preprod/media-service/network-policy.yaml
+++ b/k8s/whispr/preprod/media-service/network-policy.yaml
@@ -1,0 +1,68 @@
+# NetworkPolicy pour media-service (preprod).
+# Ingress : nginx-ingress.
+# Egress  : postgres, redis, minio (9000), auth-service (JWKS).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: media-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: media-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis nginx-ingress
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3012
+          protocol: TCP
+    # gRPC interne (ex: messaging-service demande une URL presignee)
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50012
+          protocol: TCP
+        - port: 3012
+          protocol: TCP
+  egress:
+    # PostgreSQL
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # MinIO (S3 interne) - port API S3 et port console
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: minio
+      ports:
+        - port: 9000
+          protocol: TCP
+        - port: 9001
+          protocol: TCP
+    # auth-service (JWKS pour validation JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/preprod/messaging-service/network-policy.yaml
+++ b/k8s/whispr/preprod/messaging-service/network-policy.yaml
@@ -1,0 +1,74 @@
+# NetworkPolicy pour messaging-service (preprod).
+# Ingress : nginx-ingress (HTTP + WebSocket), appels internes depuis scheduling-service.
+# Egress  : postgres, redis, user-service (lookup contacts), notification-service (via internal token).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: messaging-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: messaging-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis nginx-ingress (HTTP + WebSocket Phoenix)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 4010
+          protocol: TCP
+    # scheduling-service peut poster des messages programmes
+    - from:
+        - podSelector:
+            matchLabels:
+              app: scheduling-service
+      ports:
+        - port: 4010
+          protocol: TCP
+    # gRPC interne
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 40010
+          protocol: TCP
+  egress:
+    # PostgreSQL
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (pub/sub Phoenix PubSub + cache)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # user-service (check_users_are_contacts, profils)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: user-service
+      ports:
+        - port: 3011
+          protocol: TCP
+    # notification-service (push notifications nouveaux messages)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP

--- a/k8s/whispr/preprod/mobile-web/network-policy.yaml
+++ b/k8s/whispr/preprod/mobile-web/network-policy.yaml
@@ -1,0 +1,29 @@
+# NetworkPolicy pour mobile-web (preprod).
+# mobile-web est un conteneur de fichiers statiques Expo Web (PWA).
+# Il ne fait aucun appel sortant cluster-interne : le navigateur client
+# appelle directement l'API via nginx-ingress.
+# Ingress : uniquement nginx-ingress.
+# Egress  : aucun (pas de backend appele depuis le pod).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mobile-web-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: mobile-web
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # nginx-ingress (serveur de fichiers statiques PWA)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3020
+          protocol: TCP
+  egress: []

--- a/k8s/whispr/preprod/moderation-service/network-policy.yaml
+++ b/k8s/whispr/preprod/moderation-service/network-policy.yaml
@@ -1,0 +1,55 @@
+# NetworkPolicy pour moderation-service (preprod).
+# Ingress : nginx-ingress (NodePort 30014 expose via service), user-service.
+# Egress  : postgres (pour stocker les sanctions et signalements).
+# Note : moderation-service est Python, pas de Redis dans les env observes.
+#        On bloque tout le reste par defaut (pas d'appel externe necessaire).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: moderation-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: moderation-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # nginx-ingress (API moderation admin)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 8000
+          protocol: TCP
+    # user-service et messaging-service peuvent soumettre des signalements
+    - from:
+        - podSelector:
+            matchLabels:
+              app: user-service
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 8000
+          protocol: TCP
+  egress:
+    # PostgreSQL (sanctions, appeals, classifier logs)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # user-service (lookup profils pour review)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: user-service
+      ports:
+        - port: 3011
+          protocol: TCP

--- a/k8s/whispr/preprod/notification-service/network-policy.yaml
+++ b/k8s/whispr/preprod/notification-service/network-policy.yaml
@@ -1,0 +1,77 @@
+# NetworkPolicy pour notification-service (preprod).
+# Ingress : auth-service et messaging-service (envoi push).
+# Egress  : postgres, redis, FCM Google (443), APNs Apple (443).
+# Note : FCM et APNs sont des endpoints HTTPS externes, le CIDR block
+#        couvre 0.0.0.0/0 sur port 443 - acceptable car il n'y a pas de
+#        plage IP fixe documentee pour ces services Google/Apple.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: notification-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: notification-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # auth-service (envoi OTP par push)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP
+    # messaging-service (push nouveaux messages)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP
+    # nginx-ingress (health check endpoint)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 4011
+          protocol: TCP
+  egress:
+    # PostgreSQL
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # FCM (Google Firebase Cloud Messaging) et APNs (Apple Push Notification service)
+    # Ces endpoints cloud n'ont pas de plage IP fixe - on autorise HTTPS sortant.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP

--- a/k8s/whispr/preprod/scheduling-service/network-policy.yaml
+++ b/k8s/whispr/preprod/scheduling-service/network-policy.yaml
@@ -1,0 +1,64 @@
+# NetworkPolicy pour scheduling-service (preprod).
+# Ingress : nginx-ingress (API programmation de messages).
+# Egress  : postgres, redis, auth-service (JWKS), messaging-service (envoi programme).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scheduling-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: scheduling-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # nginx-ingress
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3013
+          protocol: TCP
+    # gRPC interne
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50013
+          protocol: TCP
+  egress:
+    # PostgreSQL
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (jobs BullMQ / queues)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # auth-service (JWKS pour valider le JWT du createur)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP
+    # messaging-service (poster le message programme a l'echeance)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 4010
+          protocol: TCP

--- a/k8s/whispr/preprod/user-service/network-policy.yaml
+++ b/k8s/whispr/preprod/user-service/network-policy.yaml
@@ -1,0 +1,70 @@
+# NetworkPolicy pour user-service (preprod).
+# Ingress : nginx-ingress + appels internes depuis messaging-service et moderation-service.
+# Egress  : postgres, redis, auth-service (JWKS endpoint).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: user-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: user-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis nginx-ingress
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3011
+          protocol: TCP
+    # Appels HTTP internes (messaging, scheduling, moderation)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+        - podSelector:
+            matchLabels:
+              app: scheduling-service
+        - podSelector:
+            matchLabels:
+              app: moderation-service
+      ports:
+        - port: 3011
+          protocol: TCP
+    # gRPC interne
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50011
+          protocol: TCP
+  egress:
+    # PostgreSQL
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # auth-service (JWKS)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/prod/infra/network-policy-default-deny.yaml
+++ b/k8s/whispr/prod/infra/network-policy-default-deny.yaml
@@ -1,0 +1,31 @@
+# Politique de refus par defaut pour le namespace whispr-prod.
+# Identique a whispr-preprod - tout trafic bloque sauf autorisation explicite.
+# Les NetworkPolicies par service seront ajoutees dans un ticket dedie prod.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: whispr-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# DNS sortant global pour resolution de noms de service k8s.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: whispr-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Ajout d'une politique `default-deny-all` + `allow-dns-egress` dans les namespaces `whispr-preprod` et `whispr-prod` - tout trafic ingress/egress est bloque par defaut
- Ajout de 8 NetworkPolicies per-service en preprod (auth, user, media, messaging, notification, moderation, scheduling, mobile-web)
- Chaque policy autorise uniquement les flux reels identifies par audit des deployments et configmaps
- notification-service: egress HTTPS 0.0.0.0/0 (hors RFC1918) pour FCM Google + APNs Apple dont les IPs ne sont pas fixes
- prod: uniquement les policies default-deny pour l'instant - les per-service prod suivront apres validation preprod

## Test plan

- [x] YAML valide - parse `pyyaml` sans erreur sur les 10 fichiers
- [x] `kubectl apply --dry-run=server` vert sur cluster citadel preprod pour les 9 manifests preprod
- [ ] ArgoCD sync preprod - verifier `kubectl get networkpolicy -n whispr-preprod` retourne 10 policies
- [ ] Smoke test : mobile-web PWA accessible + health checks services OK apres sync
- [ ] Test lateral movement bloque : `kubectl exec -n whispr-preprod deploy/mobile-web -- curl -m 5 http://auth-service:3010/auth/v1/health/live` doit timeout

Closes WHISPR-1434