### PR TITLE
fix(k8s): JWKS egress manquant + NetworkPolicy calls-service absent [WHISPR-1436]

### DIFF
--- a/k8s/whispr/preprod/auth-service/network-policy.yaml
+++ b/k8s/whispr/preprod/auth-service/network-policy.yaml
@@ -1,7 +1,7 @@
 # NetworkPolicy pour auth-service (preprod).
-# Ingress : nginx-ingress (trafic externe) + notification-service ne l'appelle pas,
-#           mais auth l'appelle en sortie. On accepte aussi les appels internes
-#           (user, media, scheduling, messaging) pour la validation JWKS.
+# Ingress : nginx-ingress (trafic externe) + tous les services qui fetche le
+#           JWKS pour valider les JWT (user, media, scheduling, messaging,
+#           moderation, notification, calls).
 # Egress  : postgres (5432), redis (6379), notification-service (4011 gRPC)
 ---
 apiVersion: networking.k8s.io/v1
@@ -42,6 +42,12 @@ spec:
         - podSelector:
             matchLabels:
               app: moderation-service
+        - podSelector:
+            matchLabels:
+              app: notification-service
+        - podSelector:
+            matchLabels:
+              app: calls-service
       ports:
         - port: 3010
           protocol: TCP

--- a/k8s/whispr/preprod/calls-service/network-policy.yaml
+++ b/k8s/whispr/preprod/calls-service/network-policy.yaml
@@ -1,0 +1,121 @@
+# NetworkPolicy pour calls-service (preprod).
+# Ingress : nginx-ingress (HTTP + WebSocket signaling), messaging-service
+#           (webhooks LiveKit evenements), notification-service (unused direct
+#           pour l'instant mais prevu pour push appel entrant).
+# Egress  : postgres, redis, auth-service (JWKS), messaging-service (gRPC
+#           pour notifier message appel), notification-service (push appel
+#           entrant), livekit server in-cluster (API REST + RTC TCP/UDP),
+#           HTTPS 443 vers LiveKit cloud SDK (token validation, webhooks).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: calls-service-network-policy
+  namespace: whispr-preprod
+spec:
+  podSelector:
+    matchLabels:
+      app: calls-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis nginx-ingress (HTTP + WebSocket signaling Phoenix)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 4012
+          protocol: TCP
+    # messaging-service (webhooks evenements LiveKit)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 4012
+          protocol: TCP
+    # notification-service (appels internes si necessaire)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - port: 4012
+          protocol: TCP
+    # gRPC interne
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 40012
+          protocol: TCP
+  egress:
+    # PostgreSQL
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (cache sessions appels)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # auth-service (JWKS endpoint pour verify JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP
+    # notification-service (push appel entrant)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP
+    # messaging-service (notifier message appel via gRPC + HTTP)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 4010
+          protocol: TCP
+        - port: 40010
+          protocol: TCP
+    # LiveKit server in-cluster (API REST port 7880, RTC TCP 7881, RTC UDP 7882)
+    # Pod label genere par le chart livekit-server : app.kubernetes.io/name=livekit-server
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: livekit-server
+      ports:
+        - port: 7880
+          protocol: TCP
+        - port: 7881
+          protocol: TCP
+        - port: 7882
+          protocol: UDP
+    # LiveKit cloud SDK + webhooks externes (endpoints sans IP fixe)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP

--- a/k8s/whispr/preprod/messaging-service/network-policy.yaml
+++ b/k8s/whispr/preprod/messaging-service/network-policy.yaml
@@ -72,3 +72,11 @@ spec:
           protocol: TCP
         - port: 40011
           protocol: TCP
+    # auth-service (JWKS endpoint pour verify JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/preprod/moderation-service/network-policy.yaml
+++ b/k8s/whispr/preprod/moderation-service/network-policy.yaml
@@ -53,3 +53,11 @@ spec:
       ports:
         - port: 3011
           protocol: TCP
+    # auth-service (JWKS endpoint pour verify JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/preprod/notification-service/network-policy.yaml
+++ b/k8s/whispr/preprod/notification-service/network-policy.yaml
@@ -75,3 +75,11 @@ spec:
       ports:
         - port: 443
           protocol: TCP
+    # auth-service (JWKS endpoint pour verify JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Ajout egress auth-service:3010 (JWKS) sur `messaging-service`, `notification-service`, `moderation-service` - ces 3 services etaient bloqués sous default-deny NetworkPolicy de WHISPR-1433, causant `JWKS key not yet loaded` / 401 sur toutes leurs routes authentifiees
- Creation `calls-service/network-policy.yaml` entier - absent de WHISPR-1433, le service tombait sous default-deny (postgres connection refused, service mort)
- Update `auth-service/network-policy.yaml` ingress pour autoriser `calls-service` et `notification-service` a atteindre le JWKS endpoint sur :3010

## Validation

- [x] `kubectl apply --dry-run=client` vert sur les 5 fichiers (cluster preprod live)
- [x] calls-service: ingress nginx+messaging+notification, egress postgres+redis+auth+notification+messaging+livekit+HTTPS
- [x] Aucun YAML invalide transmis a ArgoCD

## Test plan

- [ ] Verifier qu'ArgoCD sync automatique applique les 5 policies (selfHeal)
- [ ] `kubectl -n whispr-preprod get networkpolicy` : `calls-service-network-policy` present
- [ ] Token JWT valide accepte sur messaging / notification / moderation (plus de 401)
- [ ] calls-service: `kubectl -n whispr-preprod logs -l app=calls-service --tail=20` sans `connection refused` postgres

Closes WHISPR-1436