### PR TITLE
[WHISPR-1449] chore(deploy/messaging-service): update image to 7ee4e68

### DIFF
--- a/k8s/whispr/preprod/messaging-service/deployment.yaml
+++ b/k8s/whispr/preprod/messaging-service/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: messaging-service
-          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-3ce6b5f
+          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-7ee4e68
           ports:
             - name: http
               containerPort: 4010

--- a/k8s/whispr/prod/messaging-service/deployment.yaml
+++ b/k8s/whispr/prod/messaging-service/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: messaging-service
-          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-3ce6b5f
+          image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-7ee4e68
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Bump messaging-service image to sha-7ee4e68 in preprod and prod
- Manual fallback because CD pipeline cannot push back to infrastructure (actions-cd[bot] returns 403 on push)
- Carries the phoenix 1.7.23 + plug_cowboy 2.8.1 CVE patches (WHISPR-1449) and the client_random bigint fix (WHISPR-1447)

## Validation
- [x] git diff limited to 2 image lines, no other change
- [x] Image was built and pushed by CI run 25639150579 to ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-7ee4e68

Closes WHISPR-1449