### PR TITLE
fix(k8s): add per-service network policies whispr-prod (incident)

### DIFF
--- a/k8s/whispr/prod/auth-service/network-policy.yaml
+++ b/k8s/whispr/prod/auth-service/network-policy.yaml
@@ -1,0 +1,86 @@
+# NetworkPolicy pour auth-service (prod).
+# Ingress : nginx-ingress (trafic externe) + tous les services qui fetche le
+#           JWKS pour valider les JWT (user, media, scheduling, messaging,
+#           moderation, notification).
+# Egress  : postgres (5432), redis (6379), notification-service (4011 gRPC).
+# Note    : en prod, postgres et redis sont dans le meme namespace whispr-prod
+#           (cf infra/postgres.yaml et infra/redis.yaml), donc on cible par
+#           podSelector au lieu de namespaceSelector comme en preprod.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: auth-service-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: auth-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis le controleur nginx-ingress (namespace ingress-nginx)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3010
+          protocol: TCP
+    # Trafic interne depuis les services whispr-prod qui fetche le JWKS
+    - from:
+        - podSelector:
+            matchLabels:
+              app: user-service
+        - podSelector:
+            matchLabels:
+              app: media-service
+        - podSelector:
+            matchLabels:
+              app: scheduling-service
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+        - podSelector:
+            matchLabels:
+              app: moderation-service
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - port: 3010
+          protocol: TCP
+    # gRPC interne (appels inter-service si necessaire)
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50010
+          protocol: TCP
+  egress:
+    # PostgreSQL (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # notification-service (envoi OTP push)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP

--- a/k8s/whispr/prod/media-service/network-policy.yaml
+++ b/k8s/whispr/prod/media-service/network-policy.yaml
@@ -1,0 +1,71 @@
+# NetworkPolicy pour media-service (prod).
+# Ingress : nginx-ingress + appels internes gRPC depuis tous services
+#           (ex: messaging-service demande une URL presignee).
+# Egress  : postgres, redis, minio (9000 + 9001), auth-service (JWKS).
+# Note    : en prod, postgres, redis et minio sont in-namespace whispr-prod,
+#           on cible par podSelector au lieu de namespaceSelector.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: media-service-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: media-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis nginx-ingress
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3012
+          protocol: TCP
+    # gRPC interne (ex: messaging-service demande une URL presignee)
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50012
+          protocol: TCP
+        - port: 3012
+          protocol: TCP
+  egress:
+    # PostgreSQL (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # MinIO (S3 interne) - port API S3 et port console (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: minio
+      ports:
+        - port: 9000
+          protocol: TCP
+        - port: 9001
+          protocol: TCP
+    # auth-service (JWKS pour validation JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/prod/messaging-service/network-policy.yaml
+++ b/k8s/whispr/prod/messaging-service/network-policy.yaml
@@ -1,0 +1,85 @@
+# NetworkPolicy pour messaging-service (prod).
+# Ingress : nginx-ingress (HTTP + WebSocket Phoenix), scheduling-service.
+# Egress  : postgres, redis, user-service (contacts), notification-service
+#           (push), auth-service (JWKS), media-service (URL presignees).
+# Note    : en prod, postgres et redis sont in-namespace whispr-prod, on cible
+#           par podSelector au lieu de namespaceSelector.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: messaging-service-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: messaging-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis nginx-ingress (HTTP + WebSocket Phoenix)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 4010
+          protocol: TCP
+    # scheduling-service peut poster des messages programmes
+    - from:
+        - podSelector:
+            matchLabels:
+              app: scheduling-service
+      ports:
+        - port: 4010
+          protocol: TCP
+    # gRPC interne
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 40010
+          protocol: TCP
+  egress:
+    # PostgreSQL (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (in-namespace whispr-prod) - pub/sub Phoenix PubSub + cache
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # user-service (check_users_are_contacts, profils)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: user-service
+      ports:
+        - port: 3011
+          protocol: TCP
+    # notification-service (push notifications nouveaux messages)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP
+    # auth-service (JWKS endpoint pour verify JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/prod/mobile-web/network-policy.yaml
+++ b/k8s/whispr/prod/mobile-web/network-policy.yaml
@@ -1,0 +1,29 @@
+# NetworkPolicy pour mobile-web (prod).
+# mobile-web est un conteneur de fichiers statiques Expo Web (PWA).
+# Il ne fait aucun appel sortant cluster-interne : le navigateur client
+# appelle directement l'API via nginx-ingress.
+# Ingress : uniquement nginx-ingress.
+# Egress  : aucun (pas de backend appele depuis le pod).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mobile-web-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: mobile-web
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # nginx-ingress (serveur de fichiers statiques PWA)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3020
+          protocol: TCP
+  egress: []

--- a/k8s/whispr/prod/moderation-service/network-policy.yaml
+++ b/k8s/whispr/prod/moderation-service/network-policy.yaml
@@ -1,0 +1,63 @@
+# NetworkPolicy pour moderation-service (prod).
+# Ingress : nginx-ingress (API moderation admin) + user-service / messaging-service (signalements).
+# Egress  : postgres (sanctions, appeals), user-service (lookup profils), auth-service (JWKS).
+# Note    : moderation-service est Python, pas de Redis dans les env observes.
+#           En prod, postgres est in-namespace whispr-prod.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: moderation-service-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: moderation-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # nginx-ingress (API moderation admin)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 8000
+          protocol: TCP
+    # user-service et messaging-service peuvent soumettre des signalements
+    - from:
+        - podSelector:
+            matchLabels:
+              app: user-service
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 8000
+          protocol: TCP
+  egress:
+    # PostgreSQL (in-namespace whispr-prod) - sanctions, appeals, classifier logs
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # user-service (lookup profils pour review)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: user-service
+      ports:
+        - port: 3011
+          protocol: TCP
+    # auth-service (JWKS endpoint pour verify JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/prod/notification-service/network-policy.yaml
+++ b/k8s/whispr/prod/notification-service/network-policy.yaml
@@ -1,0 +1,86 @@
+# NetworkPolicy pour notification-service (prod).
+# Ingress : auth-service et messaging-service (envoi push) + nginx-ingress (health).
+# Egress  : postgres, redis, FCM Google (443), APNs Apple (443), auth-service (JWKS).
+# Note    : FCM et APNs sont des endpoints HTTPS externes, le CIDR block
+#           couvre 0.0.0.0/0 sur port 443 - acceptable car il n'y a pas de
+#           plage IP fixe documentee pour ces services Google/Apple.
+#           En prod, postgres et redis sont in-namespace whispr-prod.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: notification-service-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: notification-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # auth-service (envoi OTP par push)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP
+    # messaging-service (push nouveaux messages)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 4011
+          protocol: TCP
+        - port: 40011
+          protocol: TCP
+    # nginx-ingress (health check endpoint)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 4011
+          protocol: TCP
+  egress:
+    # PostgreSQL (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # FCM (Google Firebase Cloud Messaging) et APNs (Apple Push Notification service)
+    # Ces endpoints cloud n'ont pas de plage IP fixe - on autorise HTTPS sortant.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP
+    # auth-service (JWKS endpoint pour verify JWT)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP

--- a/k8s/whispr/prod/scheduling-service/network-policy.yaml
+++ b/k8s/whispr/prod/scheduling-service/network-policy.yaml
@@ -1,0 +1,75 @@
+# NetworkPolicy pour scheduling-service (prod).
+# Ingress : nginx-ingress (API programmation de messages) + gRPC interne.
+# Egress  : postgres, redis, auth-service (JWKS), messaging-service (envoi
+#           programme), user-service (lookup destinataires).
+# Note    : en prod, postgres et redis sont in-namespace whispr-prod, on cible
+#           par podSelector au lieu de namespaceSelector.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scheduling-service-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: scheduling-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # nginx-ingress
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3013
+          protocol: TCP
+    # gRPC interne
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50013
+          protocol: TCP
+  egress:
+    # PostgreSQL (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (in-namespace whispr-prod) - jobs BullMQ / queues
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # auth-service (JWKS pour valider le JWT du createur)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP
+    # messaging-service (poster le message programme a l'echeance)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+      ports:
+        - port: 4010
+          protocol: TCP
+    # user-service (lookup destinataires)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: user-service
+      ports:
+        - port: 3011
+          protocol: TCP

--- a/k8s/whispr/prod/user-service/network-policy.yaml
+++ b/k8s/whispr/prod/user-service/network-policy.yaml
@@ -1,0 +1,73 @@
+# NetworkPolicy pour user-service (prod).
+# Ingress : nginx-ingress + appels internes depuis messaging-service,
+#           scheduling-service et moderation-service.
+# Egress  : postgres, redis, auth-service (JWKS endpoint).
+# Note    : en prod, postgres et redis sont in-namespace whispr-prod, on cible
+#           par podSelector au lieu de namespaceSelector.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: user-service-network-policy
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: user-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Trafic depuis nginx-ingress
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: 3011
+          protocol: TCP
+    # Appels HTTP internes (messaging, scheduling, moderation)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: messaging-service
+        - podSelector:
+            matchLabels:
+              app: scheduling-service
+        - podSelector:
+            matchLabels:
+              app: moderation-service
+      ports:
+        - port: 3011
+          protocol: TCP
+    # gRPC interne
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 50011
+          protocol: TCP
+  egress:
+    # PostgreSQL (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Redis (in-namespace whispr-prod)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # auth-service (JWKS)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - port: 3010
+          protocol: TCP


### PR DESCRIPTION
## Context

Production incident on `whispr-api.roadmvn.com` for ~27h.

PR #227 (WHISPR-1434) introduced `default-deny-all` + `allow-dns-egress` NetworkPolicies in the `whispr-prod` namespace **without** the matching per-service allow rules. Result: all application pods lost egress to postgres / redis and went into `CrashLoopBackOff` (auth, user, media, messaging, notification).

In `whispr-preprod` the per-service NetworkPolicies already exist and are what makes that environment work.

## Summary

- adds one `network-policy.yaml` per service in `k8s/whispr/prod/<service>/`
- mirrors the preprod ruleset (ingress nginx-ingress + peer services, egress postgres / redis / JWKS / push providers as needed)
- key adaptation: in prod, postgres / redis / minio live inside the `whispr-prod` namespace (see `infra/postgres.yaml`, `infra/redis.yaml`, `infra/minio.yaml`), so egress targets are `podSelector` rather than `namespaceSelector` like in preprod
- no calls-service in prod yet, so no policy for it
- mobile-web: ingress nginx only, no egress (static PWA)

## Files

- auth-service
- user-service
- media-service
- messaging-service
- notification-service
- scheduling-service
- moderation-service
- mobile-web

## Validation

- [x] `kubectl apply --dry-run=client` clean for all 8 manifests against the live cluster
- [x] labels on prod postgres / redis / minio pods checked: `app=postgresql`, `app=redis`, `app=minio`
- [x] ingress-nginx namespace carries `kubernetes.io/metadata.name=ingress-nginx`
- [ ] ArgoCD sync of each service Application picks up the new manifest
- [ ] `kubectl -n whispr-prod rollout restart` brings pods out of CrashLoopBackOff
- [ ] `https://whispr-api.roadmvn.com/auth/health` returns 200

Closes WHISPR-1452.