### PR TITLE
fix(k8s): allow ingress to postgres redis minio in whispr-prod

### DIFF
--- a/k8s/whispr/prod/infra/network-policy-allow-ingress.yaml
+++ b/k8s/whispr/prod/infra/network-policy-allow-ingress.yaml
@@ -1,0 +1,21 @@
+# NetworkPolicy d'ingress pour les pods infra (postgresql, redis, minio) dans whispr-prod.
+# default-deny-all bloque tout, et les NPs par service ont bien un egress vers postgres/redis/minio,
+# mais les pods infra eux-memes n'avaient aucune regle d'ingress -> ECONNREFUSED au boot des backends.
+# Cette regle autorise l'ingress depuis tous les pods de la meme namespace whispr-prod.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: infra-services-allow-ingress
+  namespace: whispr-prod
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [postgresql, redis, minio]
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}


### PR DESCRIPTION
## Summary
- Add NetworkPolicy `infra-services-allow-ingress` in `whispr-prod` allowing in-namespace pod-to-pod ingress to postgresql, redis and minio
- Already applied live at 21:48 GMT+2 to unblock prod (auth-service Running). Commit this file so ArgoCD selfHeal does not wipe it.

## Incident
Prod was down 27h.
- `default-deny-all` in `whispr-prod` selects ALL pods including the infra ones (postgresql, redis, minio).
- Per-service NetworkPolicies (`auth-service`, `user-service`, `media-service`, `messaging-service`, `notification-service`...) correctly set egress to postgres/redis/minio.
- But infra pods had no NetworkPolicy with ingress rules, so they rejected every connection.
- Backends got `ECONNREFUSED` at boot and CrashLoopBackOff'd.

## Validation
- [x] `kubectl apply --dry-run=client -f` returns `configured` (validated on the live cluster)
- [x] Manifest content already matches what is live on `whispr-prod` since 2026-05-10 21:48 GMT+2
- [ ] ArgoCD `citadel-infra` sync stays clean after merge
- [ ] Live NetworkPolicy not overwritten after sync

Closes WHISPR-1453