### PR TITLE
fix(k8s): allow auth-service prod egress to twilio api over 443

### DIFF
--- a/k8s/whispr/prod/auth-service/network-policy.yaml
+++ b/k8s/whispr/prod/auth-service/network-policy.yaml
@@ -2,10 +2,13 @@
 # Ingress : nginx-ingress (trafic externe) + tous les services qui fetche le
 #           JWKS pour valider les JWT (user, media, scheduling, messaging,
 #           moderation, notification).
-# Egress  : postgres (5432), redis (6379), notification-service (4011 gRPC).
+# Egress  : postgres (5432), redis (6379), notification-service (4011 gRPC),
+#           Twilio API (HTTPS 443 externe pour envoi SMS OTP en prod reelle).
 # Note    : en prod, postgres et redis sont dans le meme namespace whispr-prod
 #           (cf infra/postgres.yaml et infra/redis.yaml), donc on cible par
 #           podSelector au lieu de namespaceSelector comme en preprod.
+#           Twilio egress non present en preprod car TWILIO_AUTH_TOKEN y est
+#           un mock, donc le SDK ne tente pas la connexion sortante.
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -83,4 +86,19 @@ spec:
         - port: 4011
           protocol: TCP
         - port: 40011
+          protocol: TCP
+    # Twilio API (envoi OTP par SMS). Endpoint HTTPS externe api.twilio.com,
+    # pas de plage IP fixe documentee donc on autorise HTTPS sortant general
+    # en excluant les ranges RFC1918 (trafic interne deja regle par les rules
+    # specifiques ci-dessus). Sans cet egress, le health check Twilio fail et
+    # auth-service reste 0/1 Ready, ce qui casse tous les fetch JWKS aval.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
           protocol: TCP


### PR DESCRIPTION
## Contexte

Audit demande des NetworkPolicies app-services prod (PR #230 / #231) vs preprod
pour identifier les gaps d'egress. Decouvert ce soir en debug : auth-service
prod reste en 0/1 Ready a cause du health check Twilio qui fail (fetch failed
sur api.twilio.com), ce qui cascade et bloque tous les services aval qui
fetchent le JWKS (media-service en CrashLoopBackOff, etc).

## Audit detaille (preprod vs prod, par service)

Comparaison ligne par ligne des NetworkPolicies. Les differences attendues
(namespace whispr-preprod -> whispr-prod, postgres/redis/minio cible par
podSelector au lieu de namespaceSelector car in-namespace en prod) sont
ignorees.

| Service | Gap reel preprod -> prod |
|---|---|
| auth-service | manque egress HTTPS 443 externe (Twilio SMS). En preprod, TWILIO_AUTH_TOKEN est un mock donc le SDK ne tente pas la connexion. En prod, vrai token Twilio = vrai fetch = bloque. |
| user-service | aucun gap |
| media-service | aucun gap (egress auth-service deja present) |
| messaging-service | aucun gap |
| notification-service | aucun gap (egress externe 443 deja present pour FCM/APNs) |
| scheduling-service | prod a meme un egress user-service en plus de la preprod |
| moderation-service | aucun gap |
| mobile-web | aucun gap (egress: []) |

Conclusion : un seul vrai gap, sur auth-service prod.

## Changement

Fichier modifie : `k8s/whispr/prod/auth-service/network-policy.yaml`

Ajout d'un egress rule :
- `to: ipBlock 0.0.0.0/0 except RFC1918`
- `port 443 TCP`

Pattern identique a celui deja utilise pour notification-service (FCM/APNs).
Commentaire en tete et inline mis a jour pour expliquer le pourquoi.

## Validation

- [x] `kubectl apply --dry-run=client -f network-policy.yaml` -> configured (dry run)
- [ ] ArgoCD sync prod NetworkPolicies app
- [ ] auth-service passe en 1/1 Ready
- [ ] media-service sort du CrashLoopBackOff

## Note sur messaging-service

Le commentaire en tete de messaging-service prod NP mentionne "media-service
(URL presignees)" mais l'egress correspondant n'existe ni en preprod ni en
prod. Si necessaire, sera trace dans un ticket separe (out-of-scope ici).

Closes WHISPR-1454