### PR TITLE
fix(k8s): update messaging prod probe paths to health/live and health/ready

### DIFF
--- a/k8s/whispr/prod/messaging-service/deployment.yaml
+++ b/k8s/whispr/prod/messaging-service/deployment.yaml
@@ -30,20 +30,20 @@ spec:
                 name: messaging-service-env
           startupProbe:
             httpGet:
-              path: /messaging/api/v1/live
+              path: /messaging/api/v1/health/live
               port: 4010
             failureThreshold: 15
             periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /messaging/api/v1/ready
+              path: /messaging/api/v1/health/ready
               port: 4010
             initialDelaySeconds: 20
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /messaging/api/v1/live
+              path: /messaging/api/v1/health/live
               port: 4010
             initialDelaySeconds: 45
             periodSeconds: 30


### PR DESCRIPTION
## Summary
- Fix messaging-service prod startup/liveness/readiness probe paths to match current Phoenix router.
- Router exposes `/messaging/api/v1/health/live` and `/messaging/api/v1/health/ready`, not `/messaging/api/v1/live` and `/messaging/api/v1/ready`.
- Without this fix the pod (image sha-7ee4e68) never passes startup probe (404) and CrashLoopBackOff.

## Validation
- [x] kubectl apply --dry-run=client passes
- [ ] ArgoCD sync clean
- [ ] Pod 1/1 Running after rollout

Closes WHISPR-1455