### PR TITLE
fix(k8s): wire INTERNAL_API_TOKEN to prod deployments

### DIFF
--- a/k8s/whispr/prod/messaging-service/deployment.yaml
+++ b/k8s/whispr/prod/messaging-service/deployment.yaml
@@ -28,6 +28,12 @@ spec:
           envFrom:
             - secretRef:
                 name: messaging-service-env
+          env:
+            - name: INTERNAL_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: shared-internal-api-token
+                  key: INTERNAL_API_TOKEN
           startupProbe:
             httpGet:
               path: /messaging/api/v1/live

--- a/k8s/whispr/prod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/prod/scheduling-service/deployment.yaml
@@ -28,6 +28,12 @@ spec:
           envFrom:
             - secretRef:
                 name: scheduling-service-env
+          env:
+            - name: INTERNAL_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: shared-internal-api-token
+                  key: INTERNAL_API_TOKEN
           readinessProbe:
             httpGet:
               path: /health/ready

--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -31,6 +31,11 @@ spec:
           env:
             - name: DB_SYNCHRONIZE
               value: "false"
+            - name: INTERNAL_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: shared-internal-api-token
+                  key: INTERNAL_API_TOKEN
           readinessProbe:
             httpGet:
               path: /user/v1/health/ready


### PR DESCRIPTION
## Summary
- Add INTERNAL_API_TOKEN env via secretKeyRef shared-internal-api-token to user-service, messaging-service, scheduling-service prod deployments.
- Without this wire, services fail-closed at boot (internal auth guards reject all internal routes / contacts check returns 401).
- Same pattern as preprod for user-service and messaging-service; scheduling-service aligned for consistency.

## Validation
- [x] kubectl apply --dry-run=client OK on all 3 files (against whispr-prod cluster).
- [x] Secret shared-internal-api-token exists in ns whispr-prod with key INTERNAL_API_TOKEN.
- [ ] ArgoCD sync prod apps post-merge.
- [ ] Pods Running 1/1 post-rollout.

Closes WHISPR-1455