### PR TITLE
chore(deploy/user-service): update prod image to bfb5d97

### DIFF
--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: user-service
-          image: ghcr.io/whispr-messenger/user-service/user-service:sha-57bb5a8
+          image: ghcr.io/whispr-messenger/user-service/user-service:sha-bfb5d97
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/whispr/production/user-service/deployment.yaml
+++ b/k8s/whispr/production/user-service/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: whispr-user-api
           # the image is automatically updated by the CD pipeline with yq
-          image: ghcr.io/whispr-messenger/user-service/user-service:sha-57bb5a8
+          image: ghcr.io/whispr-messenger/user-service/user-service:sha-bfb5d97
           ports:
             - name: http
               containerPort: 3001

--- a/k8s/whispr/production/user-service/migration-job.yaml
+++ b/k8s/whispr/production/user-service/migration-job.yaml
@@ -34,7 +34,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migration
-          image: ghcr.io/whispr-messenger/user-service/user-service:sha-57bb5a8
+          image: ghcr.io/whispr-messenger/user-service/user-service:sha-bfb5d97
           command: ["/nodejs/bin/node"]
           args:
             - node_modules/typeorm/cli.js


### PR DESCRIPTION
## Summary
- Manual prod image bump apres sync deploy/preprod -> main (PR user-service #140 mergee).
- CD pipeline a build/push l'image avec succes mais a fail le push du bump (403 actions-cd[bot] denied), fallback manuel.
- INTERNAL_API_TOKEN deja wired dans deployment via PR #234 (mergee).

## Files
- k8s/whispr/prod/user-service/deployment.yaml: sha-57bb5a8 -> sha-bfb5d97
- k8s/whispr/production/user-service/deployment.yaml: sha-57bb5a8 -> sha-bfb5d97
- k8s/whispr/production/user-service/migration-job.yaml: sha-57bb5a8 -> sha-bfb5d97

## Validation
- Image build/push verifie sur run 25641895118
- INTERNAL_API_TOKEN deja present en live cluster (env wired)
- Migrations idempotentes (SeedFirstAdmin no-op, AppealTypeAndNullableSanction, CreateUserBackups) auto-run au boot