### PR TITLE
fix(k8s/media-service): retire bloc template invalide de la Service prod

### DIFF
--- a/k8s/whispr/prod/media-service/deployment.yaml
+++ b/k8s/whispr/prod/media-service/deployment.yaml
@@ -67,7 +67,3 @@ spec:
     - name: grpc
       port: 50012
       targetPort: 50012
-  template:
-    spec:
-      containers:
-        - image: ghcr.io/whispr-messenger/media-service/media-service:sha-4434e99


### PR DESCRIPTION
## Summary

- Le yq du CD bumper a injecte un bloc \`spec.template.containers.image\` dans le Service (en plus du Deployment) du fichier \`k8s/whispr/prod/media-service/deployment.yaml\`.
- ArgoCD prod bloque sur \`error calculating structured merge diff: .spec.template: field not declared in schema\` -> Sync=Unknown, sync prod gele sur sha-26e66cb.
- Le sync media-service#111 (PR de sync deploy/preprod -> main) a bumpe correctement le Deployment vers sha-4434e99 mais ArgoCD ne peut pas apply tant que le Service est mal forme.

## Validation

- [x] \`kubectl apply --dry-run=server\` clean apres le fix
- [x] Service reel en cluster non impacte (NodePort 30012/30677 inchanges)
- [ ] ArgoCD sync passe Synced apres merge