### PR TITLE
fix(k8s/user-service): wire MESSAGING_SERVICE_URL to prod

### DIFF
--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -36,6 +36,8 @@ spec:
                 secretKeyRef:
                   name: shared-internal-api-token
                   key: INTERNAL_API_TOKEN
+            - name: MESSAGING_SERVICE_URL
+              value: "http://messaging-service.whispr-prod.svc.cluster.local:4010"
           readinessProbe:
             httpGet:
               path: /user/v1/health/ready


### PR DESCRIPTION
## Summary
- L'image bfb5d97 introduit MessagingClientService qui fait configService.getOrThrow('MESSAGING_SERVICE_URL') au constructor.
- Sans la var, pod crashloop au boot avec TypeError: Configuration key MESSAGING_SERVICE_URL does not exist.
- Service messaging-service existe dans whispr-prod (NodePort 4010), wiring direct cluster-local URL.

## Validation
- messaging-service Service confirme present dans whispr-prod (kubectl get svc)
- Pattern identique au wiring INTERNAL_API_TOKEN (env: section, pas envFrom)
- URL non-secrete -> env value direct OK (pas besoin de secret)