### PR TITLE
chore(k8s/mobile-web/prod): bump image sha-b60a9ed

### DIFF
--- a/k8s/whispr/prod/mobile-web/deployment.yaml
+++ b/k8s/whispr/prod/mobile-web/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mobile-web
-          image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-4bd3396
+          image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-b60a9ed
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Aligne mobile-web prod sur main post-sync (PR mobile-app #214 sync preprod->main + #215 fix CD api url).