### PR TITLE
fix(k8s/scheduling-service): enable DB_MIGRATIONS_RUN on prod deployment

### DIFF
--- a/k8s/whispr/prod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/prod/scheduling-service/deployment.yaml
@@ -34,6 +34,10 @@ spec:
                 secretKeyRef:
                   name: shared-internal-api-token
                   key: INTERNAL_API_TOKEN
+            # Run TypeORM migrations at boot so the scheduled_messages chain
+            # creates its tables on first deploy of the registration fix.
+            - name: DB_MIGRATIONS_RUN
+              value: "true"
           readinessProbe:
             httpGet:
               path: /health/ready


### PR DESCRIPTION
## Summary
- `DB_MIGRATIONS_RUN` was missing from the prod scheduling-service env (not in secret `scheduling-service-env`).
- Combined with the typeorm migration registration fix already merged in scheduling-service, this enables the full chain to run on boot and create `scheduled_messages` + other entity tables in prod DB.
- Pod is currently logging `relation does not exist` on every cron tick.

## Validation
- [x] Dry-run apply OK from cluster
- [ ] After ArgoCD sync + rollout, confirm `SELECT to_regclass('scheduled_messages')` returns the table

Closes WHISPR-1457