### PR TITLE
[WHISPR-947] chore(istio): cap injected sidecar proxy resource requests and limits

### DIFF
--- a/helm/istio/istiod/values.yaml
+++ b/helm/istio/istiod/values.yaml
@@ -1,3 +1,17 @@
+# Global mesh-wide configuration (applied to every injected sidecar proxy)
+global:
+  proxy:
+    # Sidecar proxy resource bounds.
+    # Defaults shipped by upstream istiod (100m / 2Gi limits) are oversized for
+    # our workloads and accumulate quickly across the mesh; cap them.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
 # Pilot configuration --> ex name of istiod
 pilot:
   # Resources


### PR DESCRIPTION
## Summary
- Upstream istiod defaults give each Envoy sidecar a 100m CPU request and a 2Gi memory limit. Across the mesh this oversubscribes the cluster and leaves little headroom for new services.
- Adds `global.proxy.resources` on `helm/istio/istiod/values.yaml` so every injected sidecar gets a tight envelope (10m/64Mi requests, 200m/256Mi limits), aligned with steady-state usage observed in preprod.

## Validation
- [x] YAML parses (Python `yaml.safe_load`).
- [ ] Preprod ArgoCD: re-sync istiod app picks up the new values without diff churn outside the new `global.proxy` block.
- [ ] After rollout: spot-check `kubectl describe pod <any-pod>` and confirm the `istio-proxy` container shows the new requests/limits.

## Notes
- This only changes the *default* sidecar envelope. Services that legitimately need more (e.g. media-service streaming or livekit) can still override via the pod annotation `sidecar.istio.io/proxyCPU`, `sidecar.istio.io/proxyMemoryLimit`, etc.

Closes WHISPR-947