### PR TITLE
[WHISPR-680] chore(argocd): drop redundant HA replicas on repoServer, server and applicationSet

### DIFF
--- a/helm/argocd/values.yaml
+++ b/helm/argocd/values.yaml
@@ -16,12 +16,12 @@ controller:
 repoServer:
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 1
 
 server:
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 1
   service:
     type: ClusterIP
   metrics:
@@ -30,7 +30,7 @@ server:
     enabled: false
 
 applicationSet:
-  replicas: 2
+  replicas: 1
 
 crds:
   install: true


### PR DESCRIPTION
## Summary
- ArgoCD ran with two replicas of `repoServer`, `server` and `applicationSet`, plus a 2-replica fallback configured by the chart defaults. We have a single-zone preprod cluster behind a single ingress and a non-HA Redis, so the second replica only consumed memory and pod slots without buying availability.
- Sets `repoServer.autoscaling.minReplicas`, `server.autoscaling.minReplicas` and `applicationSet.replicas` to `1`. Autoscaling stays enabled on `repoServer` and `server`, so load spikes still scale out automatically.

## Already done in a previous change (NOT part of this PR)
- `redis-ha.enabled: false` / `redis.enabled: true` was already in place — the HA Redis sidecar for ArgoCD has been off for a while. No change in this PR.

## Out of scope (split into follow-up tickets)
- **Application Redis HA** — `helm/redis/values.yaml` still ships `architecture: replication`. Whether the application Redis needs HA is a product decision; not bundled here.
- **`redis-node-2` `ImagePullBackOff`** — this is a runtime/cluster issue (image pull on a node), unrelated to the chart values. Should be diagnosed separately.

## Validation
- [x] YAML parses (Python `yaml.safe_load`).
- [ ] Preprod ArgoCD: re-sync the argocd app — diff should show only the three replica/minReplicas dropping from 2 → 1; no other key churn.
- [ ] After rollout: `kubectl get deploy -n argocd` shows 1 replica for argocd-server, argocd-repo-server and argocd-applicationset-controller.

Closes WHISPR-680