### PR TITLE
chore(ci): disable auto sync-preprod workflow

### DIFF
--- a/.github/workflows/sync-preprod.yml
+++ b/.github/workflows/sync-preprod.yml
@@ -1,11 +1,7 @@
 name: Sync deploy/preprod with main
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'k8s/whispr/preprod/**'
-      - 'k8s/whispr/prod/**'
+  workflow_dispatch:
 
 jobs:
   sync:


### PR DESCRIPTION
Le workflow auto-merge main vers deploy/preprod fail systematiquement avec des conflicts apres les recents rewrites d'historique. ArgoCD ne suit pas deploy/preprod de toute facon. Switche en workflow_dispatch (manuel seulement).