### PR TITLE
[WHISPR-642] feat(scheduling-service): add prod migration Job manifest

### DIFF
--- a/k8s/whispr/production/scheduling-service/migration-job.yaml
+++ b/k8s/whispr/production/scheduling-service/migration-job.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: scheduling-service-migration
+  namespace: whispr-prod
+  labels:
+    app: scheduling-service
+    component: migration
+    environment: production
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: scheduling-service
+        component: migration
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: scheduling-service-sa
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: Never
+      containers:
+        - name: migration
+          image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-78e7bc4
+          command: ["/nodejs/bin/node"]
+          args:
+            - node_modules/typeorm/cli.js
+            - migration:run
+            - -d
+            - dist/modules/app/migrations/migration.config.js
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: scheduling-service-db-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: scheduling-service-db-secret
+                  key: password
+            - name: DB_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+          envFrom:
+            - configMapRef:
+                name: scheduling-service-config
+            - secretRef:
+                name: scheduling-service-db-secret
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+              ephemeral-storage: "100Mi"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"
+              ephemeral-storage: "500Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary
Cherry-pick of #202 (squash `1a60fff`) onto `main` to land the scheduling-service migration Job manifest in the prod source-of-truth.

## File added
- `k8s/whispr/production/scheduling-service/migration-job.yaml` (TypeORM PreSync hook, sync-wave 1, ttl 600s)

## Heads up — path convention
`citadel-scheduling-service` (ArgoCD prod) watches `k8s/whispr/prod/scheduling-service`, NOT `k8s/whispr/production/scheduling-service`. The migration Job manifest lives in `production/` per the convention established by `auth-service` (already on main since SPRINT 8). So **merging this PR does NOT auto-deploy** the Job on prod — it lands the manifest in git, and the Job needs to be `kubectl apply`'d manually when the prod migration window opens (or the manifest needs to move to `prod/` if the convention changes).

Consistent with the existing `k8s/whispr/production/auth-service/migration-job.yaml` pattern.

## Validation
- [x] Cherry-pick clean (1 file, no conflicts vs `main`)
- [x] Preprod equivalent merged via #202 → `deploy/preprod` (squash `1a60fff`) on 2026-05-11
- [ ] Gabriel approval before merge to `main`

Closes the prod side of WHISPR-642.
