### PR TITLE
[WHISPR-641] feat(notification-service): add prod migration Job manifest

### DIFF
--- a/k8s/whispr/production/notification-service/migration-job.yaml
+++ b/k8s/whispr/production/notification-service/migration-job.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: notification-service-migration
+  namespace: whispr-prod
+  labels:
+    app: notification-service
+    component: migration
+    environment: production
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: notification-service
+        component: migration
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: notification-service-sa
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: Never
+      containers:
+        - name: migration
+          image: ghcr.io/whispr-messenger/notification-service:sha-7bbe53d
+          command: ["/app/bin/whispr_notification"]
+          args:
+            - eval
+            - WhisprNotifications.Release.migrate()
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-db-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-db-secret
+                  key: password
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            # Phoenix runtime.exs requires a 64-byte SECRET_KEY_BASE even for
+            # migrations. The endpoint is never started by `eval`, so this
+            # placeholder is only consumed by the config validator.
+            - name: SECRET_KEY_BASE
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          envFrom:
+            - configMapRef:
+                name: notification-service-config
+            - secretRef:
+                name: notification-service-db-secret
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+              ephemeral-storage: "100Mi"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+              ephemeral-storage: "500Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL


### PR DESCRIPTION
## Summary
Cherry-pick of #203 (squash `fa17b1b`) onto `main` to land the notification-service migration Job manifest in the prod source-of-truth.

## File added
- `k8s/whispr/production/notification-service/migration-job.yaml` (Ecto PreSync hook, sync-wave 1, invoking `WhisprNotifications.Release.migrate/0`)

## Heads up — path convention
`citadel-notification-service` (ArgoCD prod) watches `k8s/whispr/prod/notification-service`, NOT `k8s/whispr/production/notification-service`. The migration Job manifest lives in `production/` per the convention established by `auth-service` already on main. So **merging this PR does NOT auto-deploy** the Job on prod — it lands the manifest in git, and the Job needs to be `kubectl apply`'d manually when the prod migration window opens.

Consistent with the existing `k8s/whispr/production/auth-service/migration-job.yaml` pattern.

## Validation
- [x] Cherry-pick clean (1 file, no conflicts vs `main`)
- [x] Preprod equivalent merged via #203 → `deploy/preprod` (squash `fa17b1b`) on 2026-05-11
- [ ] Gabriel approval before merge to `main`

Closes the prod side of WHISPR-641.
