### PR TITLE
fix(k8s/prod/auth-service): set JWT_ISSUER to auth.whispr.roadmvn.com

### DIFF
--- a/k8s/whispr/prod/auth-service/deployment.yaml
+++ b/k8s/whispr/prod/auth-service/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               containerPort: 50010
           env:
             - name: JWT_ISSUER
-              value: "https://auth.whispr.epitech.beer"
+              value: "https://auth.whispr.roadmvn.com"
             - name: JWT_AUDIENCE
               value: "whispr-api"
           envFrom:


### PR DESCRIPTION
## Summary

L'auth-service prod emettait des JWT avec iss=https://auth.whispr.epitech.beer (domaine des collegues). Les messages ne s'affichaient plus en prod car messaging-service rejetait ces tokens (claim iss mismatch).

L'instance prod chez nous (whispr-api.roadmvn.com) doit utiliser le bon issuer roadmvn.com.

## Validation
- [x] dry-run k8s OK
- [ ] ArgoCD sync apres merge
- [ ] re-login + verif live conversations prod