### PR TITLE
fix(k8s/prod): set JWT_ISSUER and JWT_AUDIENCE on messaging+user services

### DIFF
--- a/k8s/whispr/prod/messaging-service/deployment.yaml
+++ b/k8s/whispr/prod/messaging-service/deployment.yaml
@@ -34,6 +34,10 @@ spec:
                 secretKeyRef:
                   name: shared-internal-api-token
                   key: INTERNAL_API_TOKEN
+            - name: JWT_ISSUER
+              value: "https://auth.whispr.roadmvn.com"
+            - name: JWT_AUDIENCE
+              value: "whispr-api"
           startupProbe:
             httpGet:
               path: /messaging/api/v1/health/live

--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -38,6 +38,10 @@ spec:
                   key: INTERNAL_API_TOKEN
             - name: MESSAGING_SERVICE_URL
               value: "http://messaging-service.whispr-prod.svc.cluster.local:4010"
+            - name: JWT_ISSUER
+              value: "https://auth.whispr.roadmvn.com"
+            - name: JWT_AUDIENCE
+              value: "whispr-api"
           readinessProbe:
             httpGet:
               path: /user/v1/health/ready


### PR DESCRIPTION
## Summary

Sans ces env vars, messaging-service et user-service prod rejetaient les JWT emis par auth-service avec 'claim aud did not pass validation'. Les conversations ne chargeaient plus en prod et toutes les API user/messaging renvoyaient 401.

Les memes vars sont deja sur l'auth-service prod (qui signe). On aligne maintenant les services qui verifient.

Patch live deja applique via kubectl patch sur les 2 secrets prod le 2026-05-12 ; cette PR persiste la config dans le repo pour eviter qu'un re-create du secret ou re-deploy n'enleve les vars.

## Validation
- [x] live: ConversationsList prod charge sans 401 ni 'Reconnexion en cours'
- [ ] ArgoCD sync apres merge -> verifier que les pods restart sans regression