### PR TITLE
feat(k8s/prod): align prod manifests structure with preprod

### DIFF
--- a/argocd-prod-citadel/applications/auth-service.yaml
+++ b/argocd-prod-citadel/applications/auth-service.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/argocd-prod-citadel/applications/media-service.yaml
+++ b/argocd-prod-citadel/applications/media-service.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/argocd-prod-citadel/applications/messaging-service.yaml
+++ b/argocd-prod-citadel/applications/messaging-service.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/argocd-prod-citadel/applications/mobile-web.yaml
+++ b/argocd-prod-citadel/applications/mobile-web.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/argocd-prod-citadel/applications/moderation-service.yaml
+++ b/argocd-prod-citadel/applications/moderation-service.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/argocd-prod-citadel/applications/notification-service.yaml
+++ b/argocd-prod-citadel/applications/notification-service.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/argocd-prod-citadel/applications/scheduling-service.yaml
+++ b/argocd-prod-citadel/applications/scheduling-service.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/argocd-prod-citadel/applications/user-service.yaml
+++ b/argocd-prod-citadel/applications/user-service.yaml
@@ -28,3 +28,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/k8s/whispr/prod/auth-service/configmap.yaml
+++ b/k8s/whispr/prod/auth-service/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-service-config
+  namespace: whispr-prod
+data:
+  JWT_ISSUER: "https://auth.whispr.roadmvn.com"
+  JWT_AUDIENCE: "whispr-api"
+  DB_LOGGING: "false"

--- a/k8s/whispr/prod/auth-service/deployment.yaml
+++ b/k8s/whispr/prod/auth-service/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: whispr-prod
   labels:
     app: auth-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -16,37 +18,33 @@ spec:
       labels:
         app: auth-service
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: auth-service
           image: ghcr.io/whispr-messenger/auth-service/auth-service:sha-3503bde
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 3010
             - name: grpc
               containerPort: 50010
-          env:
-            - name: JWT_ISSUER
-              value: "https://auth.whispr.roadmvn.com"
-            - name: JWT_AUDIENCE
-              value: "whispr-api"
           envFrom:
             - secretRef:
                 name: auth-service-env
-          readinessProbe:
-            httpGet:
-              path: /auth/v1/health/ready
-              port: 3010
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            failureThreshold: 3
-          livenessProbe:
-            httpGet:
-              path: /auth/v1/health/live
-              port: 3010
-            initialDelaySeconds: 45
-            periodSeconds: 30
-            failureThreshold: 3
+            - configMapRef:
+                name: auth-service-config
           resources:
             requests:
               memory: 256Mi
@@ -58,25 +56,25 @@ spec:
             - name: jwt-keys
               mountPath: /app/secrets
               readOnly: true
+          startupProbe:
+            httpGet:
+              path: /auth/v1/health/ready
+              port: 3010
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /auth/v1/health/live
+              port: 3010
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /auth/v1/health/ready
+              port: 3010
+            initialDelaySeconds: 5
+            periodSeconds: 10
       volumes:
         - name: jwt-keys
           secret:
             secretName: jwt-keys
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: auth-service
-  namespace: whispr-prod
-spec:
-  type: NodePort
-  selector:
-    app: auth-service
-  ports:
-    - name: http
-      port: 3010
-      targetPort: 3010
-      nodePort: 30010
-    - name: grpc
-      port: 50010
-      targetPort: 50010

--- a/k8s/whispr/prod/auth-service/hpa.yaml
+++ b/k8s/whispr/prod/auth-service/hpa.yaml
@@ -1,0 +1,27 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: auth-service
+  namespace: whispr-prod
+  labels:
+    app: auth-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: auth-service
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/whispr/prod/auth-service/service.yaml
+++ b/k8s/whispr/prod/auth-service/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+  namespace: whispr-prod
+spec:
+  type: NodePort
+  selector:
+    app: auth-service
+  ports:
+    - name: http
+      port: 3010
+      targetPort: 3010
+      nodePort: 30010
+    - name: grpc
+      port: 50010
+      targetPort: 50010

--- a/k8s/whispr/prod/infra/shared-internal-api-token.yaml
+++ b/k8s/whispr/prod/infra/shared-internal-api-token.yaml
@@ -1,0 +1,27 @@
+---
+# Shared service-to-service auth token for the user-service ↔ messaging-service
+# internal API (WHISPR-1229: GET /internal/v1/contacts/check, header
+# x-internal-token, env INTERNAL_API_TOKEN). Both Deployments mount the same
+# Secret/key — any drift between sender and receiver yields a 401.
+#
+# The token is bootstrapped out-of-band (kubectl) and ArgoCD MUST NOT overwrite
+# the data field. We declare only the Secret shell here (metadata + type, no
+# stringData) and rely on ServerSideApply so the kubectl-applied data is owned
+# by the bootstrap (or a future Vault projection), not by Git.
+#
+# Bootstrap command (rerun to rotate; rolling-restart both Deployments after):
+#
+#   kubectl -n whispr-prod create secret generic shared-internal-api-token \
+#     --from-literal=INTERNAL_API_TOKEN="$(openssl rand -hex 32)" \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# The data key MUST be "INTERNAL_API_TOKEN" — both Deployments reference it via
+# secretKeyRef.key under that exact name.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shared-internal-api-token
+  namespace: whispr-prod
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+type: Opaque

--- a/k8s/whispr/prod/media-service/deployment.yaml
+++ b/k8s/whispr/prod/media-service/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: whispr-prod
   labels:
     app: media-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -16,10 +18,23 @@ spec:
       labels:
         app: media-service
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: media-service
           image: ghcr.io/whispr-messenger/media-service/media-service:sha-023fc86
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 3012
@@ -28,19 +43,42 @@ spec:
           envFrom:
             - secretRef:
                 name: media-service-env
-          readinessProbe:
+          env:
+            - name: MINIO_ENDPOINT
+              value: minio.whispr-prod.svc.cluster.local
+            - name: JWT_JWKS_URL
+              value: http://auth-service:3010/auth/.well-known/jwks.json
+            - name: S3_ENDPOINT
+              value: http://minio.whispr-prod.svc.cluster.local:9000
+            - name: S3_PUBLIC_ENDPOINT
+              value: https://whispr-api.roadmvn.com
+            - name: S3_FORCE_PATH_STYLE
+              value: "true"
+            - name: S3_REGION
+              value: us-east-1
+            - name: NODE_ENV
+              value: production
+          startupProbe:
             httpGet:
-              path: /media/v1/health/ready
+              path: /media/v1/health/live
               port: 3012
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 30
+            periodSeconds: 2
           livenessProbe:
             httpGet:
               path: /media/v1/health/live
               port: 3012
-            initialDelaySeconds: 45
-            periodSeconds: 30
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /media/v1/health/ready
+              port: 3012
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           resources:
             requests:
@@ -49,25 +87,3 @@ spec:
             limits:
               memory: 512Mi
               cpu: 500m
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: media-service
-  namespace: whispr-prod
-spec:
-  type: NodePort
-  selector:
-    app: media-service
-  ports:
-    - name: http
-      port: 3012
-      targetPort: 3012
-      nodePort: 30012
-    - name: grpc
-      port: 50012
-      targetPort: 50012
-  template:
-    spec:
-      containers:
-        - image: ghcr.io/whispr-messenger/media-service/media-service:sha-023fc86

--- a/k8s/whispr/prod/media-service/service.yaml
+++ b/k8s/whispr/prod/media-service/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: media-service
+  namespace: whispr-prod
+spec:
+  type: NodePort
+  selector:
+    app: media-service
+  ports:
+    - name: http
+      port: 3012
+      targetPort: 3012
+      nodePort: 30012
+    - name: grpc
+      port: 50012
+      targetPort: 50012

--- a/k8s/whispr/prod/messaging-service/configmap.yaml
+++ b/k8s/whispr/prod/messaging-service/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: messaging-service-config
+  namespace: whispr-prod
+data:
+  JWT_ISSUER: "https://auth.whispr.roadmvn.com"
+  JWT_AUDIENCE: "whispr-api"
+  USER_SERVICE_HTTP_URL: "http://user-service:3011"
+  ADMIN_USER_IDS: "3378ee73-ce43-4145-b689-ba982d97721e,fab8817a-27a0-4537-89c1-be05f783150b"

--- a/k8s/whispr/prod/messaging-service/deployment.yaml
+++ b/k8s/whispr/prod/messaging-service/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: whispr-prod
   labels:
     app: messaging-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -16,10 +18,23 @@ spec:
       labels:
         app: messaging-service
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: messaging-service
           image: ghcr.io/whispr-messenger/messaging-service/messaging-service:sha-7ee4e68
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 4010
@@ -28,16 +43,16 @@ spec:
           envFrom:
             - secretRef:
                 name: messaging-service-env
+            - configMapRef:
+                name: messaging-service-config
           env:
+            - name: HTTP_PORT
+              value: "4010"
             - name: INTERNAL_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: shared-internal-api-token
                   key: INTERNAL_API_TOKEN
-            - name: JWT_ISSUER
-              value: "https://auth.whispr.roadmvn.com"
-            - name: JWT_AUDIENCE
-              value: "whispr-api"
           startupProbe:
             httpGet:
               path: /messaging/api/v1/health/live
@@ -65,21 +80,3 @@ spec:
             limits:
               memory: 512Mi
               cpu: 500m
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: messaging-service
-  namespace: whispr-prod
-spec:
-  type: NodePort
-  selector:
-    app: messaging-service
-  ports:
-    - name: http
-      port: 4010
-      targetPort: 4010
-      nodePort: 30020
-    - name: grpc
-      port: 40010
-      targetPort: 40010

--- a/k8s/whispr/prod/messaging-service/hpa.yaml
+++ b/k8s/whispr/prod/messaging-service/hpa.yaml
@@ -1,0 +1,27 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: messaging-service
+  namespace: whispr-prod
+  labels:
+    app: messaging-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: messaging-service
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/whispr/prod/messaging-service/service.yaml
+++ b/k8s/whispr/prod/messaging-service/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: messaging-service
+  namespace: whispr-prod
+spec:
+  type: NodePort
+  selector:
+    app: messaging-service
+  ports:
+    - name: http
+      port: 4010
+      targetPort: 4010
+      nodePort: 30020
+    - name: grpc
+      port: 40010
+      targetPort: 40010

--- a/k8s/whispr/prod/mobile-web/deployment.yaml
+++ b/k8s/whispr/prod/mobile-web/deployment.yaml
@@ -16,19 +16,50 @@ spec:
       labels:
         app: mobile-web
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mobile-web
           image: ghcr.io/whispr-messenger/mobile-app/mobile-web:sha-b60a9ed
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 3020
+          env:
+            - name: ALLOWED_ORIGINS
+              value: "https://whispr.roadmvn.com,https://whispr-api.roadmvn.com"
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3020
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3020
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 3020
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           resources:
             requests:

--- a/k8s/whispr/prod/moderation-service/configmap.yaml
+++ b/k8s/whispr/prod/moderation-service/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: moderation-config
-  namespace: whispr
+  namespace: whispr-prod
 data:
   MOD_MUTE_THRESHOLD: "3"
   MOD_MUTE_DAYS: "7"

--- a/k8s/whispr/prod/moderation-service/deployment.yaml
+++ b/k8s/whispr/prod/moderation-service/deployment.yaml
@@ -18,10 +18,23 @@ spec:
       labels:
         app: moderation-service
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: moderation-service
           image: ghcr.io/whispr-messenger/moderation-service:sha-7e4116b
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 8000
@@ -30,12 +43,35 @@ spec:
                 name: moderation-service-env
             - configMapRef:
                 name: moderation-config
+          env:
+            - name: MOD_BLOCK_THRESHOLD
+              value: "0.6"
+            - name: MOD_MAX_UPLOAD_MB
+              value: "10"
+            - name: MOD_RATE_LIMIT
+              value: "30/minute"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            failureThreshold: 60
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 8000
             initialDelaySeconds: 20
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             requests:
               memory: 512Mi
@@ -43,18 +79,3 @@ spec:
             limits:
               memory: 1Gi
               cpu: 500m
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: moderation-service
-  namespace: whispr-prod
-spec:
-  type: NodePort
-  selector:
-    app: moderation-service
-  ports:
-    - name: http
-      port: 8000
-      targetPort: 8000
-      nodePort: 30014

--- a/k8s/whispr/prod/moderation-service/service.yaml
+++ b/k8s/whispr/prod/moderation-service/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moderation-service
+  namespace: whispr-prod
+  labels:
+    app: moderation-service
+spec:
+  type: NodePort
+  selector:
+    app: moderation-service
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      nodePort: 30014

--- a/k8s/whispr/prod/notification-service/configmap.yaml
+++ b/k8s/whispr/prod/notification-service/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notification-service-config
+  namespace: whispr-prod
+data:
+  APNS_KEY_PATH: "/etc/apns/AuthKey.p8"
+  APNS_KEY_ID: ""
+  APNS_TEAM_ID: ""
+  APNS_MODE: "production"

--- a/k8s/whispr/prod/notification-service/deployment.yaml
+++ b/k8s/whispr/prod/notification-service/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: whispr-prod
   labels:
     app: notification-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -16,10 +18,23 @@ spec:
       labels:
         app: notification-service
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: notification-service
           image: ghcr.io/whispr-messenger/notification-service:sha-0d19e71
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 4011
@@ -28,6 +43,8 @@ spec:
           envFrom:
             - secretRef:
                 name: notification-service-env
+            - configMapRef:
+                name: notification-service-config
           startupProbe:
             httpGet:
               path: /api/v1/health
@@ -55,21 +72,15 @@ spec:
             limits:
               memory: 512Mi
               cpu: 500m
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: notification-service
-  namespace: whispr-prod
-spec:
-  type: NodePort
-  selector:
-    app: notification-service
-  ports:
-    - name: http
-      port: 4011
-      targetPort: 4011
-      nodePort: 30021
-    - name: grpc
-      port: 40011
-      targetPort: 40011
+          volumeMounts:
+            - name: apns-key
+              mountPath: /etc/apns
+              readOnly: true
+      volumes:
+        - name: apns-key
+          secret:
+            secretName: notification-service-apns
+            items:
+              - key: AuthKey.p8
+                path: AuthKey.p8
+            optional: true

--- a/k8s/whispr/prod/notification-service/service.yaml
+++ b/k8s/whispr/prod/notification-service/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+  namespace: whispr-prod
+spec:
+  type: NodePort
+  selector:
+    app: notification-service
+  ports:
+    - name: http
+      port: 4011
+      targetPort: 4011
+      nodePort: 30021
+    - name: grpc
+      port: 40011
+      targetPort: 40011

--- a/k8s/whispr/prod/scheduling-service/deployment.yaml
+++ b/k8s/whispr/prod/scheduling-service/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: whispr-prod
   labels:
     app: scheduling-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -16,10 +18,23 @@ spec:
       labels:
         app: scheduling-service
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: scheduling-service
           image: ghcr.io/whispr-messenger/scheduling-service/scheduling-service:sha-092f330
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 3013
@@ -29,28 +44,36 @@ spec:
             - secretRef:
                 name: scheduling-service-env
           env:
+            - name: JWT_JWKS_URL
+              value: http://auth-service:3010/auth/.well-known/jwks.json
             - name: INTERNAL_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: shared-internal-api-token
                   key: INTERNAL_API_TOKEN
-            # Run TypeORM migrations at boot so the scheduled_messages chain
-            # creates its tables on first deploy of the registration fix.
             - name: DB_MIGRATIONS_RUN
               value: "true"
-          readinessProbe:
+          startupProbe:
             httpGet:
-              path: /health/ready
+              path: /health
               port: 3013
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 30
+            periodSeconds: 2
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: /health
               port: 3013
-            initialDelaySeconds: 45
-            periodSeconds: 30
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3013
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           resources:
             requests:
@@ -59,21 +82,3 @@ spec:
             limits:
               memory: 512Mi
               cpu: 500m
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: scheduling-service
-  namespace: whispr-prod
-spec:
-  type: NodePort
-  selector:
-    app: scheduling-service
-  ports:
-    - name: http
-      port: 3013
-      targetPort: 3013
-      nodePort: 30013
-    - name: grpc
-      port: 50013
-      targetPort: 50013

--- a/k8s/whispr/prod/scheduling-service/service.yaml
+++ b/k8s/whispr/prod/scheduling-service/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scheduling-service
+  namespace: whispr-prod
+spec:
+  type: NodePort
+  selector:
+    app: scheduling-service
+  ports:
+    - name: http
+      port: 3013
+      targetPort: 3013
+      nodePort: 30013
+    - name: grpc
+      port: 50013
+      targetPort: 50013

--- a/k8s/whispr/prod/user-service/configmap.yaml
+++ b/k8s/whispr/prod/user-service/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-service-config
+  namespace: whispr-prod
+data:
+  JWT_JWKS_URL: "http://auth-service.whispr-prod.svc.cluster.local:3010/auth/.well-known/jwks.json"
+  JWT_ISSUER: "https://auth.whispr.roadmvn.com"
+  JWT_AUDIENCE: "whispr-api"
+  MESSAGING_SERVICE_URL: "http://messaging-service.whispr-prod.svc.cluster.local:4010"
+  MEDIA_SERVICE_URL: "https://whispr-api.roadmvn.com"
+  DB_LOGGING: "false"

--- a/k8s/whispr/prod/user-service/deployment.yaml
+++ b/k8s/whispr/prod/user-service/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: whispr-prod
   labels:
     app: user-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -16,10 +18,23 @@ spec:
       labels:
         app: user-service
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: user-service
           image: ghcr.io/whispr-messenger/user-service/user-service:sha-01c4c8d
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 3011
@@ -28,33 +43,39 @@ spec:
           envFrom:
             - secretRef:
                 name: user-service-env
+            - configMapRef:
+                name: user-service-config
           env:
             - name: DB_SYNCHRONIZE
               value: "false"
+            - name: SEED_ADMIN_USER_IDS
+              value: "fab8817a-27a0-4537-89c1-be05f783150b,3378ee73-ce43-4145-b689-ba982d97721e"
             - name: INTERNAL_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: shared-internal-api-token
                   key: INTERNAL_API_TOKEN
-            - name: MESSAGING_SERVICE_URL
-              value: "http://messaging-service.whispr-prod.svc.cluster.local:4010"
-            - name: JWT_ISSUER
-              value: "https://auth.whispr.roadmvn.com"
-            - name: JWT_AUDIENCE
-              value: "whispr-api"
-          readinessProbe:
+          startupProbe:
             httpGet:
-              path: /user/v1/health/ready
+              path: /user/v1/health/live
               port: 3011
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 30
+            periodSeconds: 2
           livenessProbe:
             httpGet:
               path: /user/v1/health/live
               port: 3011
-            initialDelaySeconds: 45
-            periodSeconds: 30
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /user/v1/health/ready
+              port: 3011
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           resources:
             requests:
@@ -63,21 +84,3 @@ spec:
             limits:
               memory: 512Mi
               cpu: 500m
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: user-service
-  namespace: whispr-prod
-spec:
-  type: NodePort
-  selector:
-    app: user-service
-  ports:
-    - name: http
-      port: 3011
-      targetPort: 3011
-      nodePort: 30011
-    - name: grpc
-      port: 50011
-      targetPort: 50011

--- a/k8s/whispr/prod/user-service/hpa.yaml
+++ b/k8s/whispr/prod/user-service/hpa.yaml
@@ -1,0 +1,27 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: user-service
+  namespace: whispr-prod
+  labels:
+    app: user-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: user-service
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/whispr/prod/user-service/service.yaml
+++ b/k8s/whispr/prod/user-service/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+  namespace: whispr-prod
+spec:
+  type: NodePort
+  selector:
+    app: user-service
+  ports:
+    - name: http
+      port: 3011
+      targetPort: 3011
+      nodePort: 30011
+    - name: grpc
+      port: 50011
+      targetPort: 50011


### PR DESCRIPTION
## Summary

Bring the prod GitOps tree to functional and structural parity with preprod, addressing the gaps surfaced in `docs/diff-reports/preprod-vs-prod.md`.

### Structural alignment
- Extract `Service` into standalone `service.yaml` files for the 7 services where it was inline in `deployment.yaml`. Live NodePorts preserved (auth=30010, messaging=30020, user=30011, media=30012, moderation=30014, notification=30021, scheduling=30013).
- Add missing `ConfigMap` for auth, messaging, user, notification.
- Fix the moderation `ConfigMap` namespace (`whispr` → `whispr-prod`).
- Add `HorizontalPodAutoscaler` for auth, messaging, user (min 1 / max 3, CPU 70% / Mem 80%).
- Add the shell-only `Secret/shared-internal-api-token` under `infra/` with `ServerSideApply` so ArgoCD adopts the already-bootstrapped data without overwriting it.

### Deployment hardening
On every Deployment:
- `runAsNonRoot`, `runAsUser: 1000`, `seccompProfile: RuntimeDefault`
- Container `capabilities.drop: [ALL]`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`
- `automountServiceAccountToken: false`
- Modernized probes (`startupProbe` + distinct `/live` / `/ready` endpoints)
- `envFrom.configMapRef` wired on services that gained a config
- Fixed the broken `Service` fragment left at the bottom of `media-service/deployment.yaml`

### ArgoCD
Add `ignoreDifferences /spec/replicas` to all 8 `Application` so HPAs no longer fight the GitOps sync.

### Drift fix
Correct `JWT_ISSUER` on auth-service Deployment (`epitech.beer` → `roadmvn.com`) to match what the cluster actually runs.

## Validation
- [x] `kubectl apply --dry-run=client` clean on all 32 modified/created files
- [ ] ArgoCD prod sync after merge: all `citadel-*` Applications go `Synced` + `Healthy`
- [ ] `shared-internal-api-token` adopted by ArgoCD (tracking-id annotation set)
- [ ] Post-merge: `kubectl -n whispr-prod patch secret scheduling-service-env --type='json' -p='[{"op":"add","path":"/data/DB_MIGRATIONS_RUN","value":"dHJ1ZQ=="}]'` then `rollout restart` to ensure scheduling migrations run
- [ ] Regenerate diff report — only image tags / clusterIPs / Secret `*-env` data should remain

## Out of scope (follow-ups)
- Ingress + Istio Gateway/VirtualService preprod-only (not in preprod GitOps either)
- `*-env` Secret bootstrapping (still out-of-band on both envs)
- Decide fate of `calls-service`, `livekit`, `expo-dev`, `backup`