### PR TITLE
fix(k8s/prod/mobile-web): mount emptyDirs for nginx writable paths

### DIFF
--- a/k8s/whispr/prod/mobile-web/deployment.yaml
+++ b/k8s/whispr/prod/mobile-web/deployment.yaml
@@ -68,3 +68,17 @@ spec:
             limits:
               memory: 128Mi
               cpu: 200m
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/k8s/whispr/prod/mobile-web/deployment.yaml
+++ b/k8s/whispr/prod/mobile-web/deployment.yaml
@@ -68,6 +68,7 @@ spec:
             limits:
               memory: 128Mi
               cpu: 200m
+              ephemeral-storage: 128Mi
           volumeMounts:
             - name: nginx-cache
               mountPath: /var/cache/nginx


### PR DESCRIPTION
## Summary

Hotfix for PR #247: the hardening commit set `readOnlyRootFilesystem: true` on the mobile-web container, but the image is built on nginx which writes to `/var/cache/nginx`, `/var/run` (PID file) and `/tmp` at startup. The new ReplicaSet was stuck in `CrashLoopBackOff`:

```
nginx: [emerg] mkdir() \"/var/cache/nginx/client_temp\" failed (30: Read-only file system)
```

Mount tmpfs `emptyDir` volumes on those three paths so nginx can boot while keeping the rest of the rootfs read-only.

## Validation
- [x] `kubectl apply --dry-run=client` clean
- [ ] After ArgoCD sync, new pod reaches Running 1/1 and old pod terminates