### PR TITLE
feat(k8s/preprod): version Ingress + Istio Gateway/VirtualServices in GitOps

### DIFF
--- a/argocd-preprod-citadel/applications/ingress.yaml
+++ b/argocd-preprod-citadel/applications/ingress.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: preprod-ingress
+  namespace: argocd-preprod
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/whispr-messenger/infrastructure.git
+    targetRevision: deploy/preprod
+    path: k8s/whispr/preprod/ingress
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: whispr-preprod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd-preprod-citadel/applications/istio.yaml
+++ b/argocd-preprod-citadel/applications/istio.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: preprod-istio
+  namespace: argocd-preprod
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/whispr-messenger/infrastructure.git
+    targetRevision: deploy/preprod
+    path: k8s/whispr/preprod/istio
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: whispr-preprod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/k8s/whispr/preprod/ingress/whispr-preprod-messaging-ws.yaml
+++ b/k8s/whispr/preprod/ingress/whispr-preprod-messaging-ws.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/connection-proxy-header: upgrade
+    nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+    nginx.ingress.kubernetes.io/cors-allow-headers: Authorization, Content-Type, Accept,
+      Origin, X-Requested-With, X-Device-Type
+    nginx.ingress.kubernetes.io/cors-allow-methods: GET, POST, PUT, PATCH, DELETE,
+      OPTIONS
+    nginx.ingress.kubernetes.io/cors-allow-origin: https://whispr-preprod.roadmvn.com
+    nginx.ingress.kubernetes.io/enable-cors: 'true'
+    nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '86400'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '86400'
+    nginx.ingress.kubernetes.io/proxy-set-headers: whispr-preprod/custom-headers
+    nginx.ingress.kubernetes.io/rewrite-target: /socket/$2
+    nginx.ingress.kubernetes.io/upstream-hash-by: $remote_addr
+  name: whispr-preprod-messaging-ws
+  namespace: whispr-preprod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: preprod-whispr-api.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: messaging-service
+            port:
+              number: 4010
+        path: /messaging/socket(/|$)(.*)
+        pathType: ImplementationSpecific

--- a/k8s/whispr/preprod/ingress/whispr-preprod-mobile.yaml
+++ b/k8s/whispr/preprod/ingress/whispr-preprod-mobile.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+  name: whispr-preprod-mobile
+  namespace: whispr-preprod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: whispr-preprod.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: mobile-web
+            port:
+              number: 3020
+        path: /
+        pathType: Prefix

--- a/k8s/whispr/preprod/ingress/whispr-preprod-nestjs.yaml
+++ b/k8s/whispr/preprod/ingress/whispr-preprod-nestjs.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+    nginx.ingress.kubernetes.io/cors-allow-headers: Authorization, Content-Type, Accept,
+      Origin, X-Requested-With, X-Device-Type
+    nginx.ingress.kubernetes.io/cors-allow-methods: GET, POST, PUT, PATCH, DELETE,
+      OPTIONS
+    nginx.ingress.kubernetes.io/cors-allow-origin: https://whispr-preprod.roadmvn.com
+    nginx.ingress.kubernetes.io/enable-cors: 'true'
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+  name: whispr-preprod-nestjs
+  namespace: whispr-preprod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: preprod-whispr-api.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: auth-service
+            port:
+              number: 3010
+        path: /auth
+        pathType: Prefix
+      - backend:
+          service:
+            name: user-service
+            port:
+              number: 3011
+        path: /user
+        pathType: Prefix
+      - backend:
+          service:
+            name: media-service
+            port:
+              number: 3012
+        path: /media
+        pathType: Prefix

--- a/k8s/whispr/preprod/ingress/whispr-preprod-rewrite.yaml
+++ b/k8s/whispr/preprod/ingress/whispr-preprod-rewrite.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+    nginx.ingress.kubernetes.io/cors-allow-headers: Authorization, Content-Type, Accept,
+      Origin, X-Requested-With, X-Device-Type
+    nginx.ingress.kubernetes.io/cors-allow-methods: GET, POST, PUT, PATCH, DELETE,
+      OPTIONS
+    nginx.ingress.kubernetes.io/cors-allow-origin: https://whispr-preprod.roadmvn.com
+    nginx.ingress.kubernetes.io/enable-cors: 'true'
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+    nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+    nginx.ingress.kubernetes.io/proxy-set-headers: whispr-preprod/custom-headers
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  name: whispr-preprod-rewrite
+  namespace: whispr-preprod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: preprod-whispr-api.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: messaging-service
+            port:
+              number: 4010
+        path: /messaging(/|$)(.*)
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: notification-service
+            port:
+              number: 4011
+        path: /notification(/|$)(.*)
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: scheduling-service
+            port:
+              number: 3013
+        path: /scheduling(/|$)(.*)
+        pathType: ImplementationSpecific

--- a/k8s/whispr/preprod/istio/gateway.yaml
+++ b/k8s/whispr/preprod/istio/gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: whispr-gateway
+  namespace: whispr-preprod
+spec:
+  selector:
+    istio: gateway
+  servers:
+  - hosts:
+    - preprod-whispr-api.roadmvn.com
+    - whispr-preprod.roadmvn.com
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/k8s/whispr/preprod/istio/virtualservice-mobile.yaml
+++ b/k8s/whispr/preprod/istio/virtualservice-mobile.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: whispr-mobile
+  namespace: whispr-preprod
+spec:
+  gateways:
+  - whispr-gateway
+  hosts:
+  - whispr-preprod.roadmvn.com
+  http:
+  - route:
+    - destination:
+        host: mobile-web
+        port:
+          number: 3020

--- a/k8s/whispr/preprod/istio/virtualservice-routing.yaml
+++ b/k8s/whispr/preprod/istio/virtualservice-routing.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: whispr-routing
+  namespace: whispr-preprod
+spec:
+  gateways:
+  - whispr-gateway
+  hosts:
+  - preprod-whispr-api.roadmvn.com
+  http:
+  - match:
+    - uri:
+        prefix: /auth
+    route:
+    - destination:
+        host: auth-service
+        port:
+          number: 3010
+  - match:
+    - uri:
+        prefix: /user
+    route:
+    - destination:
+        host: user-service
+        port:
+          number: 3011
+  - match:
+    - uri:
+        prefix: /media
+    route:
+    - destination:
+        host: media-service
+        port:
+          number: 3012
+  - match:
+    - uri:
+        prefix: /messaging
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: messaging-service
+        port:
+          number: 4010
+  - match:
+    - uri:
+        prefix: /notification
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: notification-service
+        port:
+          number: 4011
+  - match:
+    - uri:
+        prefix: /scheduling
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: scheduling-service
+        port:
+          number: 3013


### PR DESCRIPTION
## Summary

The 4 nginx Ingresses (`whispr-preprod-mobile`, `-nestjs`, `-messaging-ws`, `-rewrite`) and the Istio resources (`whispr-gateway`, `whispr-mobile` VS, `whispr-routing` VS) were running only in the live cluster, unmanaged by ArgoCD.

This PR brings them under GitOps so:
- Changes can be reviewed and traced through git history
- ArgoCD adopts ownership without inducing drift (manifests are byte-identical to the live state)
- The same pattern can be ported to prod in a follow-up PR

### New files
- `k8s/whispr/preprod/ingress/whispr-preprod-{mobile,nestjs,messaging-ws,rewrite}.yaml`
- `k8s/whispr/preprod/istio/gateway.yaml`
- `k8s/whispr/preprod/istio/virtualservice-{mobile,routing}.yaml`
- `argocd-preprod-citadel/applications/{ingress,istio}.yaml` (sync-wave 6)

## Validation
- [x] `kubectl apply --dry-run=server` clean on all 9 files
- [x] Live cluster manifests vs extracted files: zero diff (no behavior change)
- [ ] After merge: `preprod-ingress` and `preprod-istio` Applications go `Synced + Healthy`
- [ ] All 7 adopted resources show `argocd.argoproj.io/tracking-id` annotation

## Follow-up
- Port the same to prod (`k8s/whispr/prod/ingress` + `k8s/whispr/prod/istio` with hosts `whispr.roadmvn.com` / `whispr-api.roadmvn.com`)
- The `whispr-preprod-rewrite` and `whispr-preprod-messaging-ws` Ingresses reference a `whispr-preprod/custom-headers` ConfigMap that does not actually exist (nginx ignores silently). Either create the ConfigMap or drop the `proxy-set-headers` annotation.