### PR TITLE
feat(k8s/prod): version Ingress + Istio Gateway/VirtualServices

### DIFF
--- a/argocd-prod-citadel/applications/ingress.yaml
+++ b/argocd-prod-citadel/applications/ingress.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: citadel-ingress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/whispr-messenger/infrastructure.git
+    targetRevision: main
+    path: k8s/whispr/prod/ingress
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: whispr-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd-prod-citadel/applications/istio.yaml
+++ b/argocd-prod-citadel/applications/istio.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: citadel-istio
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/whispr-messenger/infrastructure.git
+    targetRevision: main
+    path: k8s/whispr/prod/istio
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: whispr-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/k8s/whispr/prod/ingress/whispr-prod-messaging-ws.yaml
+++ b/k8s/whispr/prod/ingress/whispr-prod-messaging-ws.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/connection-proxy-header: upgrade
+    nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+    nginx.ingress.kubernetes.io/cors-allow-headers: Authorization, Content-Type, Accept,
+      Origin, X-Requested-With, X-Device-Type
+    nginx.ingress.kubernetes.io/cors-allow-methods: GET, POST, PUT, PATCH, DELETE,
+      OPTIONS
+    nginx.ingress.kubernetes.io/cors-allow-origin: https://whispr.roadmvn.com
+    nginx.ingress.kubernetes.io/enable-cors: 'true'
+    nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '86400'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '86400'
+    nginx.ingress.kubernetes.io/proxy-set-headers: whispr-prod/custom-headers
+    nginx.ingress.kubernetes.io/rewrite-target: /socket/$2
+    nginx.ingress.kubernetes.io/upstream-hash-by: $remote_addr
+  name: whispr-prod-messaging-ws
+  namespace: whispr-prod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: whispr-api.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: messaging-service
+            port:
+              number: 4010
+        path: /messaging/socket(/|$)(.*)
+        pathType: ImplementationSpecific

--- a/k8s/whispr/prod/ingress/whispr-prod-mobile.yaml
+++ b/k8s/whispr/prod/ingress/whispr-prod-mobile.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+  name: whispr-prod-mobile
+  namespace: whispr-prod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: whispr.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: mobile-web
+            port:
+              number: 3020
+        path: /
+        pathType: Prefix

--- a/k8s/whispr/prod/ingress/whispr-prod-nestjs.yaml
+++ b/k8s/whispr/prod/ingress/whispr-prod-nestjs.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+    nginx.ingress.kubernetes.io/cors-allow-headers: Authorization, Content-Type, Accept,
+      Origin, X-Requested-With, X-Device-Type
+    nginx.ingress.kubernetes.io/cors-allow-methods: GET, POST, PUT, PATCH, DELETE,
+      OPTIONS
+    nginx.ingress.kubernetes.io/cors-allow-origin: https://whispr.roadmvn.com
+    nginx.ingress.kubernetes.io/enable-cors: 'true'
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+  name: whispr-prod-nestjs
+  namespace: whispr-prod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: whispr-api.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: auth-service
+            port:
+              number: 3010
+        path: /auth
+        pathType: Prefix
+      - backend:
+          service:
+            name: user-service
+            port:
+              number: 3011
+        path: /user
+        pathType: Prefix
+      - backend:
+          service:
+            name: media-service
+            port:
+              number: 3012
+        path: /media
+        pathType: Prefix

--- a/k8s/whispr/prod/ingress/whispr-prod-rewrite.yaml
+++ b/k8s/whispr/prod/ingress/whispr-prod-rewrite.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+    nginx.ingress.kubernetes.io/cors-allow-headers: Authorization, Content-Type, Accept,
+      Origin, X-Requested-With, X-Device-Type
+    nginx.ingress.kubernetes.io/cors-allow-methods: GET, POST, PUT, PATCH, DELETE,
+      OPTIONS
+    nginx.ingress.kubernetes.io/cors-allow-origin: https://whispr.roadmvn.com
+    nginx.ingress.kubernetes.io/enable-cors: 'true'
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+    nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+    nginx.ingress.kubernetes.io/proxy-set-headers: whispr-prod/custom-headers
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  name: whispr-prod-rewrite
+  namespace: whispr-prod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: whispr-api.roadmvn.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: messaging-service
+            port:
+              number: 4010
+        path: /messaging(/|$)(.*)
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: notification-service
+            port:
+              number: 4011
+        path: /notification(/|$)(.*)
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: scheduling-service
+            port:
+              number: 3013
+        path: /scheduling(/|$)(.*)
+        pathType: ImplementationSpecific

--- a/k8s/whispr/prod/istio/gateway.yaml
+++ b/k8s/whispr/prod/istio/gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: whispr-gateway
+  namespace: whispr-prod
+spec:
+  selector:
+    istio: gateway
+  servers:
+  - hosts:
+    - whispr-api.roadmvn.com
+    - whispr.roadmvn.com
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/k8s/whispr/prod/istio/virtualservice-mobile.yaml
+++ b/k8s/whispr/prod/istio/virtualservice-mobile.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: whispr-mobile
+  namespace: whispr-prod
+spec:
+  gateways:
+  - whispr-gateway
+  hosts:
+  - whispr.roadmvn.com
+  http:
+  - route:
+    - destination:
+        host: mobile-web
+        port:
+          number: 3020

--- a/k8s/whispr/prod/istio/virtualservice-routing.yaml
+++ b/k8s/whispr/prod/istio/virtualservice-routing.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: whispr-routing
+  namespace: whispr-prod
+spec:
+  gateways:
+  - whispr-gateway
+  hosts:
+  - whispr-api.roadmvn.com
+  http:
+  - match:
+    - uri:
+        prefix: /auth
+    route:
+    - destination:
+        host: auth-service
+        port:
+          number: 3010
+  - match:
+    - uri:
+        prefix: /user
+    route:
+    - destination:
+        host: user-service
+        port:
+          number: 3011
+  - match:
+    - uri:
+        prefix: /media
+    route:
+    - destination:
+        host: media-service
+        port:
+          number: 3012
+  - match:
+    - uri:
+        prefix: /messaging
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: messaging-service
+        port:
+          number: 4010
+  - match:
+    - uri:
+        prefix: /notification
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: notification-service
+        port:
+          number: 4011
+  - match:
+    - uri:
+        prefix: /scheduling
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: scheduling-service
+        port:
+          number: 3013


### PR DESCRIPTION
## Summary

Follow-up of #249 (which versioned the preprod equivalents). Adds the 4 nginx Ingresses and the Istio Gateway/VirtualServices in prod, with hosts adapted to:

- `whispr.roadmvn.com` (mobile-web)
- `whispr-api.roadmvn.com` (auth/user/media/messaging/notification/scheduling)

Names use the `whispr-prod-*` prefix to mirror the preprod scheme.

### New files
- `k8s/whispr/prod/ingress/whispr-prod-{mobile,nestjs,messaging-ws,rewrite}.yaml`
- `k8s/whispr/prod/istio/gateway.yaml`
- `k8s/whispr/prod/istio/virtualservice-{mobile,routing}.yaml`
- `argocd-prod-citadel/applications/{ingress,istio}.yaml` (sync-wave 6)

### CORS

`cors-allow-origin` is set to `https://whispr.roadmvn.com` on the 3 ingresses that need CORS (`nestjs`, `messaging-ws`, `rewrite`). If web is served from multiple origins (e.g. a `www.` variant), this will need a regex expansion.

## Caveat — first creation, not adoption

Unlike #249 (which adopted live preprod resources unchanged), **prod does not have these resources yet**. The first ArgoCD sync will *create* them. Verified via `kubectl get ingress,gateway,virtualservice -n whispr-prod` → empty before merge.

Pre-merge sanity:
- DNS `whispr.roadmvn.com` / `whispr-api.roadmvn.com` must already point at the cluster ingress LB
- nginx ingress controller is installed and watching `whispr-prod` namespace
- istio-gateway with label `istio: gateway` is in place

## Validation
- [x] `kubectl apply --dry-run=server` clean on all 9 files
- [ ] After merge: `citadel-ingress` and `citadel-istio` Apps go `Synced + Healthy`
- [ ] 7 resources appear in `whispr-prod` with the expected hosts
- [ ] Hitting `https://whispr.roadmvn.com` returns mobile-web, `https://whispr-api.roadmvn.com/auth/...` reaches auth-service

## Follow-up
- `whispr-prod-messaging-ws` and `whispr-prod-rewrite` reference a `whispr-prod/custom-headers` ConfigMap which does not exist (same situation as preprod — nginx ignores silently). Either create the ConfigMap or drop the annotation.